### PR TITLE
Add documentation

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -415,7 +415,7 @@ This example assumes that all prerequisites are installed and configured.
 
    .. code-block:: sh
 
-      ./gsc build --insecure-args python generic.manifest
+      ./gsc build --insecure-args python test/generic.manifest
 
 #. Sign the graminized Docker image using :command:`gsc sign-image`:
 

--- a/test/generic.manifest
+++ b/test/generic.manifest
@@ -1,0 +1,2 @@
+sgx.enclave_size = "4G"
+sgx.thread_num = 8


### PR DESCRIPTION
Documentation config is taken from the core Gramine repo and slightly modified (C specific configs are replaced/removed). The main text is taken from the core repo's `manpages/gsc.rst`.

**TODO:** This commit should be merged after commits that modify GSC files to use `gramine` words everywhere instead of `graphene`. Because the description of GSC is updated in this commit to use these `gramine` commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/3)
<!-- Reviewable:end -->
