### PR TITLE
Print SGX enclave attributes in `gsc info-image` command

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -302,6 +302,8 @@ def read_sigstruct(sig):
     SGX_ARCH_ENCLAVE_CSS_ENCLAVE_HASH = 960
     SGX_ARCH_ENCLAVE_CSS_ISV_PROD_ID = 1024
     SGX_ARCH_ENCLAVE_CSS_ISV_SVN = 1026
+    SGX_ARCH_ENCLAVE_CSS_ATTRIBUTES = 928
+    SGX_ARCH_ENCLAVE_CSS_MISC_SELECT = 900
     # Field format: (offset, type, value)
     fields = {
         'date': (SGX_ARCH_ENCLAVE_CSS_DATE, '<HBB', 'year', 'month', 'day'),
@@ -309,6 +311,8 @@ def read_sigstruct(sig):
         'enclave_hash': (SGX_ARCH_ENCLAVE_CSS_ENCLAVE_HASH, '32s', 'enclave_hash'),
         'isv_prod_id': (SGX_ARCH_ENCLAVE_CSS_ISV_PROD_ID, '<H', 'isv_prod_id'),
         'isv_svn': (SGX_ARCH_ENCLAVE_CSS_ISV_SVN, '<H', 'isv_svn'),
+        'attributes': (SGX_ARCH_ENCLAVE_CSS_ATTRIBUTES, '8s8s', 'flags', 'xfrms'),
+        'misc_select': (SGX_ARCH_ENCLAVE_CSS_MISC_SELECT, '4s', 'misc_select'),
     }
     attr = {}
     for field in fields.values():
@@ -346,6 +350,11 @@ def gsc_info_image(args):
             sigstruct['isv_prod_id'] = attr['isv_prod_id']
             sigstruct['isv_svn'] = attr['isv_svn']
             sigstruct['date'] = '%d-%02d-%02d' % (attr['year'], attr['month'], attr['day'])
+            sigstruct['flags'] = attr['flags'].hex()
+            sigstruct['xfrms'] = attr['xfrms'].hex()
+            sigstruct['misc_select'] = attr['misc_select'].hex()
+            # DEBUG attribute of the enclave is very important, so we print it also separately
+            sigstruct['debug'] = bool(attr['flags'][0] & 0b10)
 
         if not sigstruct:
             print(f'Could not extract Intel SGX-related information from image {args.image}.')


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

SGX enclave attributes are important for security. The DEBUG bit is especially important, so `gsc info-image` also prints its value
separately.

## How to test this PR? <!-- (if applicable) -->

Verified manually. Here is the result for the sample Python GSC image (without `sgx.debug = 0`, so debug enclave by default):
```
$ ./gsc info-image gsc-python
mr_enclave = "9fd86a8f07027d9b1f2c11636cd23fc3b8539524111e368e6830b0c650dc4e16"
mr_signer = "1e32238c1832c135f517eb400dcc0fab2b27cfcd16303de9faf754433c16f5ea"
isv_prod_id = 0
isv_svn = 0
date = "2021-09-29"
flags = "0600000000000000"
xfrms = "0300000000000000"
misc_select = "00000000"
debug = true
```

Here is the same but with `sgx.debug = 0` (set in `test/generic.manifest`):
```
$ ./gsc info-image gsc-python
mr_enclave = "a3953269aa4002b5b6936716c6bd97780f1904d3cba8b1ef271f166ddc72df97"
mr_signer = "1e32238c1832c135f517eb400dcc0fab2b27cfcd16303de9faf754433c16f5ea"
isv_prod_id = 0
isv_svn = 0
date = "2021-09-29"
flags = "0400000000000000"
xfrms = "0300000000000000"
misc_select = "00000000"
debug = false
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/21)
<!-- Reviewable:end -->
