### PR TITLE
Update GSC to build and run latest Gramine version

### DIFF
--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -50,7 +50,7 @@ def generate_trusted_files(root_dir, already_added_files):
     exclude_re = re.compile(excluded_paths_regex)
 
     num_trusted = 0
-    trusted_files = ''
+    trusted_files = 'sgx.trusted_files = [\n'
     for root, _, files in os.walk(root_dir.encode('UTF-8'), followlinks=False):
         for file in files:
             filename = os.path.join(root, file)
@@ -78,10 +78,11 @@ def generate_trusted_files(root_dir, already_added_files):
                 # user manifest already contains this file (probably as allowed or protected)
                 continue
 
-            trusted_files += f'sgx.trusted_files.file{num_trusted} = {trusted_file_entry}\n'
+            trusted_files += f'  {trusted_file_entry},\n'
             num_trusted += 1
 
     print(f'\t[from inside Docker container] Found {num_trusted} files in `{root_dir}`.')
+    trusted_files += f']\n'
     return trusted_files
 
 

--- a/templates/Dockerfile.ubuntu.build.template
+++ b/templates/Dockerfile.ubuntu.build.template
@@ -18,10 +18,17 @@ RUN apt-get update \
         python3 \
         python3-pip \
         python3-protobuf \
-    && python3 -B -m pip install protobuf jinja2 'toml>=0.10'
+    && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
-RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y gdb less strace vim python3-pyelftools
+RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        gdb \
+        less \
+        libunwind8 \
+        python3-pyelftools \
+        python3-pytest \
+        strace \
+        vim
 {% endif %}
 
 RUN locale-gen en_US.UTF-8

--- a/templates/Dockerfile.ubuntu.compile.template
+++ b/templates/Dockerfile.ubuntu.compile.template
@@ -12,6 +12,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         git \
         libcurl4-openssl-dev \
         libprotobuf-c-dev \
+        linux-headers-generic \
         ninja-build \
         pkg-config \
         protobuf-c-compiler \
@@ -27,14 +28,21 @@ RUN cd /gramine \
     && git fetch origin {{Gramine.Branch}} \
     && git checkout {{Gramine.Branch}}
 
-{% if SGXDriver.Repository %}
-RUN cd /gramine/Pal/src/host/Linux-SGX \
-    && git clone {{SGXDriver.Repository}} linux-sgx-driver \
-    && cd linux-sgx-driver \
-    && git checkout {{SGXDriver.Branch}}
-ENV ISGX_DRIVER_PATH "/gramine/Pal/src/host/Linux-SGX/linux-sgx-driver"
-{% else %}
+# Latest Gramine doesn't use ISGX_DRIVER_PATH but we keep it for backward compatibility
 ENV ISGX_DRIVER_PATH ""
+ENV ISGX_DRIVER_MESON ""
+
+{% if SGXDriver.Repository %}
+RUN cd /gramine \
+    && git clone {{SGXDriver.Repository}} driver \
+    && cd driver \
+    && git checkout {{SGXDriver.Branch}}
+ENV ISGX_DRIVER_PATH "/gramine/driver"
+  {% if "SGXDataCenterAttestationPrimitives" in SGXDriver.Repository %}
+  ENV ISGX_DRIVER_MESON "-Dsgx_driver=dcap1.10 -Dsgx_driver_include_path=/gramine/driver/driver/linux/include/"
+  {% elif "linux-sgx-driver" in SGXDriver.Repository %}
+  ENV ISGX_DRIVER_MESON "-Dsgx_driver=oot -Dsgx_driver_include_path=/gramine/driver/"
+  {% endif %}
 {% endif %}
 
 RUN cd /gramine \
@@ -43,5 +51,6 @@ RUN cd /gramine \
     && meson setup build/ --prefix="/gramine/meson_build_output" \
        --buildtype={% if debug %}debug{% else %}release{% endif %} \
        -Ddirect=enabled -Dsgx=enabled \
+       ${ISGX_DRIVER_MESON} \
     && ninja -C build \
     && ninja -C build install

--- a/templates/apploader.template
+++ b/templates/apploader.template
@@ -11,7 +11,7 @@ export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$(find /gramine/meson_build_output/li
 # Set default PAL to Linux-SGX
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
-    gramine-sgx-get-token -output /entrypoint.token -sig /entrypoint.sig
+    gramine-sgx-get-token --sig /entrypoint.sig --output /entrypoint.token
     gramine-sgx /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
 else
     gramine-direct /entrypoint {{binary_arguments}} "${@}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Latest Gramine versions switched from Makefiles with their `ISGX_DRIVER_PATH` envvar to Meson with its `-Dsgx_driver` and
`-Dsgx_driver_include_path`. Also, latest Gramine deprecates syntax `sgx.trusted_files.key = "file"` and prefers `sgx.trusted_files = []`.

## How to test this PR? <!-- (if applicable) -->

Try examples.