### PR TITLE
[Docs] Remove warning about "not ready for production"

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -4,11 +4,6 @@
 :program:`gsc` -- Gramine Shielded Containers
 =============================================
 
-.. warning::
-    GSC is still under development and must not be used in production! Please
-    see `issue #13 <https://github.com/gramineproject/gsc/issues/13>`__ for a
-    description of missing features and security caveats.
-
 Synopsis
 ========
 


### PR DESCRIPTION
Remove warning message https://gramine.readthedocs.io/projects/gsc/en/latest/. All documented security issues from #13 have been addressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/24)
<!-- Reviewable:end -->
