### PR TITLE
Use proper TOML parser instead of ad-hoc string-based parsing

### DIFF
--- a/templates/entrypoint.manifest.template
+++ b/templates/entrypoint.manifest.template
@@ -22,7 +22,9 @@ loader.argv0_override = "{{binary}}"
 loader.insecure__use_cmdline_argv = true
 {% else %}
 loader.argv_src_file = "file:/trusted_argv"
-sgx.trusted_files.trusted_argv = "file:/trusted_argv"
+sgx.trusted_files = [
+  "file:/trusted_argv",
+]
 {% endif %}
 
 # All trusted files and the user defined manifest specifications should be after this line

--- a/test/generic.manifest
+++ b/test/generic.manifest
@@ -1,2 +1,6 @@
 sgx.enclave_size = "4G"
 sgx.thread_num = 8
+
+sgx.trusted_files = [
+  "file:/entrypoint.manifest",  # unused entry, only to test merging of manifests
+]


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR fixes the toml duplicate entry error seen during gsc sign-image step.  Previously, our ad-hoc string-based TOML parser could not correctly handle cases like the following (the parser simply concatenated contents of two files which resulted in duplicate `sgx.trusted_files` TOML key, which is prohibited):

    # entrypoint.manifest.template contains the following snippet
    sgx.trusted_files = [
      "file:/trusted_argv",
    ]

    # application-specific manifest contains the following snippet
    sgx.trusted_files = [
      "file:app_specific_file",
    ]

This PR merges data from templates/entrypoint.manifest.template and application-specific manifest , and creates unique entries  ( by updating gsc.py).
Also, the auto-generated trusted files are correctly merged into sgx.trusted_files [] (by updating finalize_manifest.py).

**Note:** Old dictionary based format for trusted_files , allowed_files, and protected_files keys is still supported.
                 sgx.allowed_files.file1 = "file:files/plain.txt"    // still supported by gsc.


<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Gsc build and sign steps should work smoothly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/26)
<!-- Reviewable:end -->
