### PR TITLE
Update GSC to use `loader.entrypoint` instead of `loader.preload`

### DIFF
--- a/templates/entrypoint.manifest.template
+++ b/templates/entrypoint.manifest.template
@@ -1,5 +1,5 @@
+loader.entrypoint = "file:/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/libsysdb.so"
 libos.entrypoint = "/{{binary}}"
-loader.preload = "file:/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/libsysdb.so"
 
 loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:{{"{{library_paths}}"}}"
 loader.env.PATH = "{{"{{env_path}}"}}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Must be merged after gramineproject/gramine#194.

## How to test this PR? <!-- (if applicable) -->

Run some GSC examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/28)
<!-- Reviewable:end -->
