### PR TITLE
Display error message when Manifest file path is incorrect

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -196,9 +196,11 @@ def gsc_build(args):
     base_image_dict = toml.loads(base_image_environment)
 
     user_manifest_contents = ''
-    if os.path.exists(args.manifest):
-        with open(args.manifest, 'r') as user_manifest_file:
-            user_manifest_contents = user_manifest_file.read()
+    if not os.path.exists(args.manifest):
+        raise FileNotFoundError(f'Manifest file {args.manifest} does not exist')
+    with open(args.manifest, 'r') as user_manifest_file:
+        user_manifest_contents = user_manifest_file.read()
+
     user_manifest_dict = toml.loads(user_manifest_contents)
 
     # Support deprecated syntax: replace old-style TOML-dict (`sgx.trusted_files.key = "file:foo"`)


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Currently GSC does not throw any error when user_manifest file is not present at the path specified by the user, instead gsc build proceeds silently with empty user_manifest file and default manifest options. This problem is severe as the user will not know if he provided a wrong user_manifest path and the configs that are specified in the user_manifest file (such as enclave_size) will not take effect. This may lead to unexpected results while running the gsc image (such as insufficient enclave memory, if the image requires large enclave_size)


## How to test this PR? <!-- (if applicable) -->
1. Provide a wrong manifest path (means manifest file is not present at the specified path): an exception will be thrown.
2. Provide correct manifest path: gsc build will proceed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/33)
<!-- Reviewable:end -->
