### PR TITLE
Fix LD_LIBRARY_PATH in Ubuntu 21.04 Docker images

### DIFF
--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -87,6 +87,11 @@ def generate_library_paths():
 
     # Library paths start without whitespace (in contrast to libraries found under this path)
     ld_paths = (line for line in ld_paths if not re.match(r'(^\s)', line))
+
+    # ldconfig utility in Ubuntu 21.04 produces output lines like
+    # “/usr/local/lib: (from /etc/ld.so.conf.d/libc.conf:2)” – must take only the first part
+    # of this line (the actual path name)
+    ld_paths = ((line.split('(from')[0]).rstrip() for line in ld_paths)
     return ''.join(ld_paths) + os.getenv('LD_LIBRARY_PATH', default='')
 
 

--- a/templates/entrypoint.manifest.template
+++ b/templates/entrypoint.manifest.template
@@ -1,7 +1,8 @@
 loader.entrypoint = "file:/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/libsysdb.so"
 libos.entrypoint = "/{{binary}}"
 
-loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:{{"{{library_paths}}"}}"
+# ldconfig in Ubuntu 21.04 doesn't produce "/usr/lib/x86_64-linux-gnu" so add it explicitly
+loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu:{{"{{library_paths}}"}}"
 loader.env.PATH = "{{"{{env_path}}"}}"
 loader.log_level = {% if debug %} "all" {% else %} "error" {% endif %}
 


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR fixes “bash: error while loading shared libraries: libtinfo.so.6: cannot open shared object file: No such file or directory” error, seen in Ubuntu 21.04 gsc-images.  ldconfig utility in Ubuntu 21.04 images produces output lines like “/usr/local/lib: (from /etc/ld.so.conf.d/libc.conf:2)”. Here, only the first part of this line (the actual path name) should be taken, so we put a filter as part of generate_library_paths() code in finalize_manifest.py.

**Before including the fix in finalize_manifest.py:**

**For Ubuntu-21.04** 
LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu/libfakeroot: (from /etc/ld.so.conf.d/fakeroot-x86_64-linux-gnu.conf:1)/usr/local/lib: (from /etc/ld.so.conf.d/libc.conf:2)/lib/x86_64-linux-gnu: (from /etc/ld.so.conf.d/x86_64-linux-gnu.conf:3)/lib: (from <builtin>:0)"

**For Ubuntu-18.04**
LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu/libfakeroot:/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/lib:/usr/lib:"

**After including the fix in finalize_manifest.py:**

**For Ubuntu-21.04** 
LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu/libfakeroot:/usr/local/lib:/lib/x86_64-linux-gnu:/lib:"

**For Ubuntu-18.04** 
LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu/libfakeroot:/usr/local/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/lib:/usr/lib:"

The fix in finalize_manifest.py was only to remove the “(from …)” statements from ldconfig -v output.  With that fix, we continue to see the error “bash: error while loading shared libraries: libtinfo.so.6: cannot open shared object file: No such file or directory”.

By comparing Ubuntu 21.04 and Ubuntu 18.04 LD_LIBRARY_PATH, we can see that , “/usr/lib/x86_64-linux-gnu” is not part of Ubuntu 21.04 LD_LIBRARY_PATH, so we updated loader.env.LD_LIBRARY_PATH in entrypoint.manifest.template  

## How to test this PR? <!-- (if applicable) -->
gsc-bash images for Ubuntu 18.04 and Ubuntu 21.04 should work smoothly. Dockerfile and manifest file for bash image are present in gsc/test folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/40)
<!-- Reviewable:end -->
