### PR TITLE
Remove unused `fs.root.path`

### DIFF
--- a/templates/entrypoint.common.manifest.template
+++ b/templates/entrypoint.common.manifest.template
@@ -7,7 +7,6 @@ loader.env.PATH = "{{"{{env_path}}"}}"
 loader.log_level = {% if debug %} "all" {% else %} "error" {% endif %}
 
 fs.root.type = "chroot"
-fs.root.path = "/"
 fs.root.uri = "file:/"
 
 # Gramine's default working dir is '/', so change the working directory to the desired one


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Apparently, it was never used in Gramine. Looks like it was a remnant of some very-old times.

See some discussion on this here: https://github.com/gramineproject/gramine/pull/417

## How to test this PR? <!-- (if applicable) -->

N/A. I manually ran a couple GSC tests, everything still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/47)
<!-- Reviewable:end -->
