### PR TITLE
Fix missing cryptography module error after gramine-sgx-gen-private-key tool

### DIFF
--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -12,6 +12,7 @@ RUN dnf update -y \
         openssl \
         protobuf-c-devel \
         python3 \
+        python3-cryptography \
         python3-pip \
         python3-protobuf \
     && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'

--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -10,12 +10,12 @@ RUN dnf update -y \
         autoconf \
         bison \
         curl \
-        epel-release \
         elfutils-libelf-devel \
+        epel-release \
         flex \
         gawk \
-        git \
         gcc-c++ \
+        git \
         httpd \
         libcurl-devel \
         libevent-devel \
@@ -23,13 +23,13 @@ RUN dnf update -y \
         ncurses-devel \
         ninja-build \
         openssl-devel \
-        openssl-devel \
-        protobuf-devel \
-        protobuf-c-devel \
         patch \
-        protobuf-c-compiler \
-        python3 \
         pkg-config \
+        protobuf-c-compiler \
+        protobuf-c-devel \
+        protobuf-devel \
+        python3 \
+        python3-cryptography \
         python3-pip \
         python3-protobuf \
         rpm-build \

--- a/templates/ubuntu/Dockerfile.build.template
+++ b/templates/ubuntu/Dockerfile.build.template
@@ -9,6 +9,7 @@ RUN apt-get update \
         locales-all \
         openssl \
         python3 \
+        python3-cryptography \
         python3-pip \
         python3-protobuf \
     && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'

--- a/templates/ubuntu/Dockerfile.compile.template
+++ b/templates/ubuntu/Dockerfile.compile.template
@@ -17,6 +17,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         pkg-config \
         protobuf-c-compiler \
         python3 \
+        python3-cryptography \
         python3-pip \
         python3-protobuf \
         wget \


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

With `gramine-sgx-gen-private-key` checked-in to gramine master, GSC is failing with the following error:

```
  File "/gramine/meson_build_output/bin/gramine-sgx-sign", line 11, in <module>
    from graminelibos import (
  File "/gramine/meson_build_output/lib/python3.8/site-packages/graminelibos/__init__.py", line 25, in <module>
    from .sgx_sign import get_tbssigstruct, sign_with_local_key, SGX_LIBPAL, SGX_RSA_KEY_PATH
  File "/gramine/meson_build_output/lib/python3.8/site-packages/graminelibos/sgx_sign.py", line 16, in <module>
    from cryptography.hazmat import backends
ModuleNotFoundError: No module named 'cryptography'
```

This module is required irrespective of whether you are using the tool.  
Flow of import files is as follows:
`gramine-sgx-sign`  -> `graminelibos` -> `sgx_sign` -> `cryptography`

With this PR the old way of generating the signing key and passing to `gramine-sgx-sign` will work.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/48)
<!-- Reviewable:end -->
