### PR TITLE
Change Python scripts' shebang to `/usr/bin/python3`

### DIFF
--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -34,7 +34,7 @@ ENV PATH="/gramine/meson_build_output/bin:$PATH"
 
 # Mark apploader.sh executable, finalize manifest, and remove intermediate scripts
 RUN chmod u+x /apploader.sh \
-    && python3 -B /finalize_manifest.py \
+    && /usr/bin/python3 -B /finalize_manifest.py \
     && rm -f /finalize_manifest.py
 
 # Define default command

--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -15,7 +15,7 @@ RUN dnf update -y \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
-    && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
+    && /usr/bin/python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
 RUN dnf install -y \

--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -34,5 +34,5 @@ RUN dnf update -y \
         python3-protobuf \
         rpm-build \
         wget \
-    && python3 -B -m pip install 'toml>=0.10' 'meson>=0.55'
+    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.55'
 {% endblock %}

--- a/templates/ubuntu/Dockerfile.build.template
+++ b/templates/ubuntu/Dockerfile.build.template
@@ -12,7 +12,7 @@ RUN apt-get update \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
-    && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
+    && /usr/bin/python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
 RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/templates/ubuntu/Dockerfile.compile.template
+++ b/templates/ubuntu/Dockerfile.compile.template
@@ -21,5 +21,5 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         python3-pip \
         python3-protobuf \
         wget \
-    && python3 -B -m pip install 'toml>=0.10' 'meson>=0.55'
+    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.55'
 {% endblock %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine Python utilities should use the system-wide Python interpreter instead of the local version of Python (which may not have system-wide-installed Python packages). This was detected when running the default Python Ubuntu Docker image.

## How to test this PR? <!-- (if applicable) -->

Run example: https://gramine.readthedocs.io/projects/gsc/en/latest/#example