### PR TITLE
Add pip install cryptography package for python image

### DIFF
--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -15,7 +15,7 @@ RUN dnf update -y \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
-    && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
+    && python3 -B -m pip install click cryptography jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
 RUN dnf install -y \

--- a/templates/ubuntu/Dockerfile.build.template
+++ b/templates/ubuntu/Dockerfile.build.template
@@ -12,7 +12,7 @@ RUN apt-get update \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
-    && python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
+    && python3 -B -m pip install click cryptography jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
 RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Recently gsc sign image started throwing error "No module named 'cryptography'" for python base image. Issue Link:
https://github.com/gramineproject/gramine/issues/482

This PR resolves the above issue by adding pip install cryptography to Dockerfile.build.template files.

## How to test this PR ?
Step 1: docker pull python
Step 2: ./gsc build --insecure-args python test/generic.manifest
Step 3:  ./gsc sign-image python enclave-key.pem    // this should pass

example link: https://gramine.readthedocs.io/projects/gsc/en/latest/#example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/50)
<!-- Reviewable:end -->
