### PR TITLE
Add support for specifying an image registry

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -298,6 +298,12 @@ in :file:`config.yaml.template`.
    distros are Ubuntu 18.04, Ubuntu 20.04, Ubuntu 21.04 and CentOS 8. Default
    value is ``ubuntu:18.04``.
 
+.. describe:: Registry
+
+   Defines the registry and repository where the Linux distribution
+   image is located. Only needed if the image in `Distro` requires to
+   be prepended with this information.
+
 .. describe:: Gramine.Repository
 
    Source repository of Gramine. Default value:

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -2,6 +2,10 @@
 # ``ubuntu:18.04``, ``ubuntu:20.04``, ``ubuntu:21.04`` and ``centos:8``.
 Distro: "ubuntu:18.04"
 
+# If the image has a specific registry, define it here.
+# Empty by default; example value: "registry.access.redhat.com/ubi8".
+Registry: ""
+
 # If you're using your own fork and branch of Gramine, specify the GitHub link and the branch name
 # below; typically, you want to keep the default values though
 Gramine:

--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -1,4 +1,8 @@
+{% if Registry|length %}
+FROM {{Registry}}/{{Distro}} AS gramine
+{% else %}
 FROM {{Distro}} AS gramine
+{% endif %}
 
 # Install distro-specific packages to build Gramine (e.g., python3, protobuf, toml, etc.)
 {% block install %}{% endblock %}


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->


Added a `Registry` variable to the config template, and the jinja2 logic to the Dockerfile template to make use of it if present. Fixes #51.
## How to test this PR? <!-- (if applicable) -->

1. Existing builds should work as expected, i.e. no regression from the existing situation.
2. Using image names with registry paths in it should now work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/52)
<!-- Reviewable:end -->
