### PR TITLE
Mac os fix

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -39,12 +39,13 @@ def get_docker_image(docker_socket, image_name):
 
 def build_docker_image(docker_api, build_path, image_name, dockerfile, **kwargs):
     build_path = str(build_path) # Docker API doesn't understand PathLib's PosixPath type
-    stream = docker_api.build(path=build_path, tag=image_name, dockerfile=dockerfile, decode=True,
-                              **kwargs)
+    stream = docker_api.build(path=build_path, tag=image_name, dockerfile=dockerfile,
+                              decode=True, **kwargs)
     for chunk in stream:
         encoding = sys.stdout.encoding if sys.stdout.encoding is not None else 'UTF-8'
         if 'stream' in chunk:
-            print(chunk)
+            for line in chunk['stream'].splitlines():
+                print(line)
 
 
 def extract_binary_cmd_from_image_config(config, env):

--- a/gsc.py
+++ b/gsc.py
@@ -39,14 +39,12 @@ def get_docker_image(docker_socket, image_name):
 
 def build_docker_image(docker_api, build_path, image_name, dockerfile, **kwargs):
     build_path = str(build_path) # Docker API doesn't understand PathLib's PosixPath type
-    stream = docker_api.build(path=build_path, tag=image_name, dockerfile=dockerfile,
+    stream = docker_api.build(path=build_path, tag=image_name, dockerfile=dockerfile, decode=True,
                               **kwargs)
     for chunk in stream:
         encoding = sys.stdout.encoding if sys.stdout.encoding is not None else 'UTF-8'
-        json_output = json.loads(chunk.decode(encoding))
-        if 'stream' in json_output:
-            for line in json_output['stream'].splitlines():
-                print(line)
+        if 'stream' in chunk:
+            print(chunk)
 
 
 def extract_binary_cmd_from_image_config(config, env):


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Upon running 'gsc build' on macOS, the following error was encountered.
```
> ./gsc build --insecure-args python test/generic.manifest
Traceback (most recent call last):
  File "/Users/ibecker/gsc/./gsc", line 12, in <module>
    sys.exit(main(sys.argv))
  File "/Users/ibecker/./gsc.py", line 476, in main
    return args.command(args)
  File "/Users/ibecker/gsc/./gsc.py", line 237, in gsc_build
    build_docker_image(docker_socket.api, tmp_build_path, unsigned_image_name, 'Dockerfile.build',
  File "/Users/ibecker/gsc/./gsc.py", line 46, in build_docker_image
    json_output = json.loads(chunk.decode(encoding))
  File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 2 column 1 (char 55)
```
Through some debugging it was discovered that there was an error in the creation of the JSON which resulted in the apparent concatenation of two separate JSON blobs. Due to this, the JSON could not be parsed by the Python JSON parser. It appears that the [Docker daemon itself is returning](https://github.com/docker/docker-py/issues/2468#issuecomment-559325580) the erroneous JSON.

Upon inspecting the docker-py API, it was discovered that there is an [option to request a JSON decode](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.build.BuildApiMixin.build) directly through Docker, which is able to parse the JSON without issue. When using this option, the build is successful and everything else works.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Use gsc build on macOS. I do not know if the changes will work on Linux or Windows.