### PR TITLE
Allow normal user to run GSC images

### DIFF
--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -107,7 +107,7 @@ def main(args=None):
     env = jinja2.Environment(loader=jinja2.FileSystemLoader('/'))
     env.globals.update({'library_paths': generate_library_paths(), 'env_path': os.getenv('PATH')})
 
-    manifest = '/entrypoint.manifest'
+    manifest = '/gramine/app_files/entrypoint.manifest'
     rendered_manifest = env.get_template(manifest).render()
     rendered_manifest_dict = toml.loads(rendered_manifest)
     already_added_files = extract_files_from_user_manifest(rendered_manifest_dict)

--- a/gsc.py
+++ b/gsc.py
@@ -124,6 +124,12 @@ def extract_build_args(args):
                 sys.exit(1)
     return buildargs_dict
 
+def extract_user_from_image_config(config):
+    user = config['User']
+    if not user:
+        user = "root"
+    return user
+
 def merge_two_dicts(dict1, dict2, path=[]):
     for key in dict2:
         if key in dict1:
@@ -167,6 +173,8 @@ def gsc_build(args):
     env.globals.update(yaml.safe_load(args.config_file))
     env.globals.update(vars(args))
     env.globals.update({'app_image': original_image_name})
+    original_image_user = extract_user_from_image_config(original_image.attrs['Config'])
+    env.globals.update({'app_user': original_image_user})
     extract_binary_cmd_from_image_config(original_image.attrs['Config'], env)
     extract_working_dir_from_image_config(original_image.attrs['Config'], env)
 

--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -8,6 +8,11 @@ FROM gsc-{{Gramine.Image}} AS gramine
 # Combine Gramine image with the original app image
 FROM {{app_image}}
 
+# App image "user" is stored, and execution will continue as root to install packages.
+# In the signed graminized image, the "user" will be restored.
+ENV app_user={{app_user}}
+USER root
+
 # Install distro-specific packages to run Gramine (e.g., python3, protobuf, toml, etc.)
 {% block install %}{% endblock %}
 
@@ -18,10 +23,19 @@ COPY --from=gramine /gramine/ /gramine/
 COPY --from=gramine /gramine/meson_build_output /gramine/meson_build_output
 {% endif %}
 
+# Create a directory that will store apploader.sh and entrypoint files.
+RUN mkdir -p /gramine/app_files
+
+# Make the app image user owner of /gramine/app_files directory
+RUN chown $app_user /gramine/app_files/
+
+# Grant the owner of the directory (i.e., the app image user here) all the permissions
+RUN chmod u+rwx /gramine/app_files/
+
 # Copy helper scripts and Gramine manifest
 COPY *.py /
-COPY apploader.sh /
-COPY entrypoint.manifest /
+COPY apploader.sh /gramine/app_files/
+COPY entrypoint.manifest /gramine/app_files/
 
 # Generate trusted arguments if required
 {% if not insecure_args %}
@@ -37,10 +51,10 @@ RUN cd / \
 ENV PATH="/gramine/meson_build_output/bin:$PATH"
 
 # Mark apploader.sh executable, finalize manifest, and remove intermediate scripts
-RUN chmod u+x /apploader.sh \
+RUN chmod u+x /gramine/app_files/apploader.sh \
     && /usr/bin/python3 -B /finalize_manifest.py \
     && rm -f /finalize_manifest.py
 
 # Define default command
-ENTRYPOINT ["/bin/bash", "/apploader.sh"]
+ENTRYPOINT ["/bin/bash", "/gramine/app_files/apploader.sh"]
 CMD [{% if insecure_args %} "{{'", "'.join(cmd)}}" {% endif %}]

--- a/templates/Dockerfile.common.sign.template
+++ b/templates/Dockerfile.common.sign.template
@@ -1,15 +1,18 @@
 # Sign image in a separate stage to ensure that signing key is never part of the final image
 FROM {{image}} as unsigned_image
 
-COPY gsc-signer-key.pem /gsc-signer-key.pem
+COPY gsc-signer-key.pem /gramine/app_files/gsc-signer-key.pem
 
 RUN {% block path %}{% endblock %} gramine-sgx-sign \
-      --key /gsc-signer-key.pem \
-      --manifest /entrypoint.manifest \
-      --output /entrypoint.manifest.sgx
+      --key /gramine/app_files/gsc-signer-key.pem \
+      --manifest /gramine/app_files/entrypoint.manifest \
+      --output /gramine/app_files/entrypoint.manifest.sgx
 
 # This trick removes all temporary files from the previous commands (including gsc-signer-key.pem)
 FROM {{image}}
 
-COPY --from=unsigned_image /*.sig /
-COPY --from=unsigned_image /*.sgx /
+COPY --from=unsigned_image /gramine/app_files/*.sig /gramine/app_files/
+COPY --from=unsigned_image /gramine/app_files/*.sgx /gramine/app_files/
+
+# Exit root user and restore back the app image user
+USER $app_user

--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -8,8 +8,8 @@ set -ex
 # Default to Linux-SGX if no PAL was specified
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
-    gramine-sgx-get-token --sig /entrypoint.sig --output /entrypoint.token
-    gramine-sgx /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
+    gramine-sgx-get-token --sig /gramine/app_files/entrypoint.sig --output /gramine/app_files/entrypoint.token
+    gramine-sgx /gramine/app_files/entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
 else
-    gramine-direct /entrypoint {{binary_arguments}} "${@}"
+    gramine-direct /gramine/app_files/entrypoint {{binary_arguments}} "${@}"
 fi

--- a/test/generic.manifest
+++ b/test/generic.manifest
@@ -5,5 +5,5 @@ sgx.enclave_size = "4G"
 sgx.thread_num = 8
 
 sgx.trusted_files = [
-  "file:/entrypoint.manifest",  # unused entry, only to test merging of manifests
+  "file:/gramine/app_files/entrypoint.manifest",  # unused entry, only to test merging of manifests
 ]


### PR DESCRIPTION
Signed-off-by: “Veena <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Currently, gsc does not support building app images that has a non-root user.

The gsc build step fails at line https://github.com/gramineproject/gsc/blob/master/templates/Dockerfile.common.build.template#L11  , with the error as shown below

_E: List directory /var/lib/apt/lists/partial is missing. - Acquire (2: No such file or directory)_

This error occurs because distro-specific packages cannot be installed as non-root user.

If one bypass this error by putting "USER root" at https://github.com/gramineproject/gsc/blob/master/templates/Dockerfile.common.build.template#L10 , then the unsigned image and the final signed gsc image will have user as "root".

This PR allows to create gsc images for app images with non-root user. Also, the original "user" of the app image will be restored back in the final signed gsc image.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Step 1: `docker pull <non-root-user-app-image>`   //example of non-root user image [bitnami pytorch](https://github.com/bitnami/bitnami-docker-pytorch/blob/master/1/debian-10/Dockerfile#L28)
Step 2: `docker inspect non-root-user-app-image`  // here you can check the original user
Step 3: perform gsc build and gsc sign on the _non-root-user-app-image_
Step 4: `docker inspect gsc-non-root-user-app-image`  // Verify again, the image will have the original user
Step 5: `docker run --device=/dev/sgx_enclave -it gsc-non-root-user-app-image`  //success

Step 6: gsc build and sign should pass for root user images as well.

**Note:** If the app image has an empty user field like user : "" , then the final gsc image will be created with root user. 