### PR TITLE
Allow to skip SGX token generation

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -101,6 +101,11 @@ Gramine image.
    Allow untrusted arguments to be specified at :command:`docker run`. Otherwise
    any arguments specified during :command:`docker run` are ignored.
 
+.. option:: --skip-token-generation
+
+   Allows to skip SGX token generation (via :command:`gramine-sgx-get-token`).
+   Useful for DCAP platforms and read-only filesystems.
+
 .. option:: --no-cache
 
    Disable Docker's caches during :command:`gsc build`. This builds the

--- a/gsc.py
+++ b/gsc.py
@@ -425,6 +425,9 @@ sub_build.add_argument('-L', '--linux', action='store_true',
 sub_build.add_argument('--insecure-args', action='store_true',
     help='Allow to specify untrusted arguments during Docker run. '
          'Otherwise arguments are ignored.')
+sub_build.add_argument('--skip-token-generation', action='store_true',
+    help='Allows to skip SGX token generation (via `gramine-sgx-get-token`). '
+         'Useful for DCAP platforms and read-only filesystems.')
 sub_build.add_argument('-nc', '--no-cache', action='store_true',
     help='Build graminized Docker image without any cached images.')
 sub_build.add_argument('--rm', action='store_true',

--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -8,7 +8,9 @@ set -ex
 # Default to Linux-SGX if no PAL was specified
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
+    {% if not skip_token_generation %}
     gramine-sgx-get-token --sig /entrypoint.sig --output /entrypoint.token
+    {% endif %}
     gramine-sgx /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
 else
     gramine-direct /entrypoint {{binary_arguments}} "${@}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

SGX Launch Token (aka EINITTOKEN) is generated right-before Gramine launch via the `gramine-sgx-get-token` tool. For DCAP platforms, the SGX token is unused, so there is no need to generate it. This commit introduces a GSC switch `--skip-token-generation` for this.

This is useful for DCAP platforms (one less file in the Docker container), and enables such scenarios as `docker run --read-only`.
Also, skipping running `gramine-sgx-get-token` paves a path to removing Python as a run-time dependency for GSC-built Docker images.

Related PR in core Gramine: https://github.com/gramineproject/gramine/pull/363

## How to test this PR? <!-- (if applicable) -->

A Python example from docs with `./gsc build --skip-token-generation --insecure-args python test/generic.manifest`. You'll see that `gramine-sgx-get-token` tool is not called during the last step (`docker run`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/62)
<!-- Reviewable:end -->
