### PR TITLE
Remove `set -x` from `apploader.sh` entrypoint script

### DIFF
--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-set -ex
+{% if debug %}
+set -x
+{% endif %}
+set -e
 
 # Export distro-specific paths (typically `PYTHONPATH` and `PKG_CONFIG_PATH`)
 {% block path %}{% endblock %}
@@ -8,7 +11,7 @@ set -ex
 # Default to Linux-SGX if no PAL was specified
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
-    gramine-sgx-get-token --sig /entrypoint.sig --output /entrypoint.token
+    gramine-sgx-get-token --quiet --sig /entrypoint.sig --output /entrypoint.token
     gramine-sgx /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
 else
     gramine-direct /entrypoint {{binary_arguments}} "${@}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It printed all executed steps and commands by the shell script, which is unneeded for normal user. Kept only for debug environments.

## How to test this PR? <!-- (if applicable) -->

- This shows the commands:
```
./gsc build --debug --insecure-args python test/generic.manifest
```

- This doesn't show the commands:
```
./gsc build --insecure-args python test/generic.manifest
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/63)
<!-- Reviewable:end -->
