### PR TITLE
Copy Gramine files with permissions of the Docker image user

### DIFF
--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -25,9 +25,9 @@ USER {{app_user}}
 
 # Copy path-specific installation of Gramine
 {% if debug %}
-COPY --from=gramine /gramine/ /gramine/
+COPY --from=gramine --chown={{app_user}} /gramine/ /gramine/
 {% else %}
-COPY --from=gramine /gramine/meson_build_output /gramine/meson_build_output
+COPY --from=gramine --chown={{app_user}} /gramine/meson_build_output /gramine/meson_build_output
 {% endif %}
 
 # Copy helper scripts and Gramine manifest


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

In commit "Support Docker images that have a non-root user", we forgot to mark Gramine files to be copied with permissions of the Docker image user. This led to these files being copies with root permissions, and during the signing step GSC failed to access them.

Fixes #68.

## How to test this PR? <!-- (if applicable) -->

Try a non-root-user Docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/69)
<!-- Reviewable:end -->
