### PR TITLE
Introduce `binary` and `binary_basename` in GSC templates

### DIFF
--- a/templates/entrypoint.common.manifest.template
+++ b/templates/entrypoint.common.manifest.template
@@ -1,4 +1,4 @@
-libos.entrypoint = "/gramine/app_files/{{binary}}"
+libos.entrypoint = "/gramine/app_files/{{binary_basename}}"
 
 # Add distro-specific `loader.entrypoint` and `loader.env.LD_LIBRARY_PATH`
 {% block loader %}{% endblock %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR contains ~three~ ~two~ one commit (~rather independent but hit these three issues while trying OpenVINO~):

~- Set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` during GSC steps. Core Gramine uses a pre-generated `_pb2.py` file, which became out of date with the new release of the Google Protobuf Python lib. GSC started to failing because of this during the build & sign steps. Technically, core Gramine should not use the pre-generated file but instead create this file on demand. But this requires some modifications in core Gramine. A simple workaround for this issue is suggested by Protobuf devs: set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`.~

- Previously, GSC templates used `which {{binary}}` to find the absolute path to the entrypoint binary. GSC sets the `binary` variable here to the basename of the Docker image's ENTRYPOINT. So the `which {{binary}}` command worked well for binaries found in PATH, but failed for binaries not under PATH but rather specified using absolute/relative path. This commit changes GSC to set the `binary` variable to the full path. For the cases when the basename of the binary is needed, we introduce a new variable `binary_basename`.

~- [Examples] Fix OpenVINO to build and run. OpenVINO native build got affected by Google Protobuf Python lib update and requires the `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` workaround. Also, OpenVINO now has a proper ENTRYPOINT, with an absolute path to the executable (previously it was a relative path to the symlink to the executable, which confused Gramine and led to failures).~

~Fixes #65.~

## How to test this PR? <!-- (if applicable) -->

- To test PATH binary, try the classic Python example (https://gramine.readthedocs.io/projects/gsc/en/latest/#example).

- To test non-PATH absolute-path binary, try our OpenVINO example.

- To test non-PATH relative-path binary, try the modified `ubuntu18.04-bash` example from `tests/`. Modify the Dockerfile like this:
```diff
diff --git a/test/ubuntu18.04-bash.dockerfile b/test/ubuntu18.04-bash.dockerfile
@@ -2,4 +2,6 @@ From ubuntu:18.04

 RUN apt-get update

-CMD ["bash"]
+WORKDIR /bin/
+
+ENTRYPOINT ["./bash"]
```

- To test non-PATH relative-path binary (another example), try the modified `ubuntu18.04-bash` example from `tests/`. Modify the Dockerfile like this:
```diff
diff --git a/test/ubuntu18.04-bash.dockerfile b/test/ubuntu18.04-bash.dockerfile
@@ -2,4 +2,4 @@ From ubuntu:18.04

 RUN apt-get update

-CMD ["bash"]
+ENTRYPOINT ["bin/bash"]

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/71)
<!-- Reviewable:end -->
