### PR TITLE
Add `protobuf-compiler` dependency

### DIFF
--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -28,6 +28,7 @@ RUN dnf update -y \
         pkg-config \
         protobuf-c-compiler \
         protobuf-c-devel \
+        protobuf-compiler \
         protobuf-devel \
         python3 \
         python3-cryptography \

--- a/templates/ubuntu/Dockerfile.compile.template
+++ b/templates/ubuntu/Dockerfile.compile.template
@@ -17,6 +17,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         ninja-build \
         pkg-config \
         protobuf-c-compiler \
+        protobuf-compiler \
         python3 \
         python3-cryptography \
         python3-pip \


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

This dependency is required to compile `aesm_pb2.py` during Gramine build.

Companion PR to https://github.com/gramineproject/gramine/pull/701.

## How to test this PR? <!-- (if applicable) -->

Try any Docker image, e.g., Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/72)
<!-- Reviewable:end -->
