### PR TITLE
Add `python3-pyelftools` dependency

### DIFF
--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -15,6 +15,7 @@ RUN dnf update -y \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
+        python3-pyelftools \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
@@ -22,7 +23,6 @@ RUN dnf install -y \
         gdb \
         less \
         libunwind \
-        python3-pyelftools \
         python3-pytest \
         strace \
         vim

--- a/templates/ubuntu/Dockerfile.build.template
+++ b/templates/ubuntu/Dockerfile.build.template
@@ -12,6 +12,7 @@ RUN apt-get update \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
+        python3-pyelftools \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
 
 {% if debug %}
@@ -19,7 +20,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gdb \
         less \
         libunwind8 \
-        python3-pyelftools \
         python3-pytest \
         strace \
         vim


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This dependency is required to run `gramine-sgx-sign` Gramine tool (after core Gramine's commit "[python] Use elftools to parse ELF").

See https://github.com/gramineproject/gramine/commit/83e8ae050bc9a06bf1d80ac008322c5bcbb2d041 and https://github.com/gramineproject/gramine/pull/735 for core Gramine where it was introduced.

## How to test this PR? <!-- (if applicable) -->

Try example Python image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/74)
<!-- Reviewable:end -->
