### PR TITLE
Provide full binary path for loader argv

### DIFF
--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -38,7 +38,7 @@ COPY --chown={{app_user}} entrypoint.manifest /gramine/app_files/
 # Generate trusted arguments if required
 {% if not insecure_args %}
 RUN /gramine/meson_build_output/bin/gramine-argv-serializer \
-        {{binary}} {{binary_arguments}} "{{"\" \"".join(cmd)}}" > /gramine/app_files/trusted_argv
+        /gramine/app_files/{{binary_basename}} {{binary_arguments}} "{{"\" \"".join(cmd)}}" > /gramine/app_files/trusted_argv
 {% endif %}
 
 # Docker entrypoint/cmd typically contains only the basename of the executable so create a symlink

--- a/templates/entrypoint.common.manifest.template
+++ b/templates/entrypoint.common.manifest.template
@@ -19,7 +19,7 @@ sgx.debug = {% if debug %} true {% else %} false {% endif %}
 # !! INSECURE !! Allow passing command-line arguments from the host without validation.
 # Most Docker images rely on runtime arguments and hence, a more general technique is required.
 # The issue is documented at https://github.com/gramineproject/gsc/issues/13.
-loader.argv0_override = "{{binary}}"
+loader.argv0_override = "/gramine/app_files/{{binary_basename}}"
 loader.insecure__use_cmdline_argv = true
 {% else %}
 loader.argv_src_file = "file:/gramine/app_files/trusted_argv"


### PR DESCRIPTION
This fixes certain situations when the loader is unable to locate the binary (cases where libos entrypoint and just the binary name as argv dont resolve to the same thing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/77)
<!-- Reviewable:end -->
