### PR TITLE
Remove `libcurl-dev` dependency

### DIFF
--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -17,7 +17,6 @@ RUN dnf update -y \
         gcc-c++ \
         git \
         httpd \
-        libcurl-devel \
         libevent-devel \
         make \
         nasm \

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -8,7 +8,6 @@ RUN apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         binutils \
         expect \
-        libcurl4-openssl-dev \
         libprotobuf-c-dev \
         locales \
         openssl \

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -10,7 +10,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         curl \
         gawk \
         git \
-        libcurl4-openssl-dev \
         libprotobuf-c-dev \
         linux-headers-generic \
         nasm \

--- a/templates/debian/Dockerfile.sign.template
+++ b/templates/debian/Dockerfile.sign.template
@@ -9,7 +9,6 @@ RUN \
           toml \
        && apt-get remove -y binutils \
           expect \
-          libcurl4-openssl-dev \
           openssl \
           python3-pip \
           python3-protobuf \


### PR DESCRIPTION
This dependency is not required for `tools/sgx` in Gramine after the core Gramine's commit "[tools/sgx,curl,Docs] Link all dependencies of tools/sgx statically".

Relates to https://github.com/gramineproject/gramine/pull/773.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/81)
<!-- Reviewable:end -->
