### PR TITLE
Upgrade Meson to ">= 0.56"

### DIFF
--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -36,5 +36,5 @@ RUN dnf update -y \
         python3-protobuf \
         rpm-build \
         wget \
-    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.55'
+    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.56'
 {% endblock %}

--- a/templates/ubuntu/Dockerfile.compile.template
+++ b/templates/ubuntu/Dockerfile.compile.template
@@ -23,7 +23,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         python3-pip \
         python3-protobuf \
         wget \
-    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.55'
+    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.56'
 
 COPY intel-sgx-deb.key /
 


### PR DESCRIPTION
"meson >= 0.56" is required for properly linking static libraries with custom targets.

See https://github.com/gramineproject/gramine/pull/773#pullrequestreview-1051815308 for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/82)
<!-- Reviewable:end -->
