### PR TITLE
Add option to use signing key protected by a passphrase

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -144,6 +144,10 @@ of the signing key in them.
 
    Specify configuration file. Default: :file:`config.yaml`
 
+.. option:: -p
+
+   Provide passphrase for the enclave signing key (if applicable)
+
 .. option:: IMAGE-NAME
 
    Name of the application Docker image

--- a/sign.sh
+++ b/sign.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/expect
+spawn gramine-sgx-sign \
+      --key [lindex $argv 0] \
+      --manifest [lindex $argv 1] \
+      --output [lindex $argv 2]
+
+set timeout -1
+set times 0
+set maxtimes 1
+expect "Enter pass phrase for [lindex $argv 0]" {
+    if {$times > $maxtimes} {
+        exit 0
+    }
+    send "[lindex $argv 3]\r"
+    set times [ expr $times + 1];
+    exp_continue
+}

--- a/templates/Dockerfile.common.sign.template
+++ b/templates/Dockerfile.common.sign.template
@@ -1,14 +1,19 @@
 # Sign image in a separate stage to ensure that signing key is never part of the final image
 FROM {{image}} as unsigned_image
-
 COPY gsc-signer-key.pem /gramine/app_files/gsc-signer-key.pem
 
-RUN {% block path %}{% endblock %} gramine-sgx-sign \
-      --key /gramine/app_files/gsc-signer-key.pem \
-      --manifest /gramine/app_files/entrypoint.manifest \
-      --output /gramine/app_files/entrypoint.manifest.sgx
+ARG passphrase
+COPY sign.sh /gramine/app_files/sign.sh
+RUN chmod +x /gramine/app_files/sign.sh
 
-# This trick removes all temporary files from the previous commands (including gsc-signer-key.pem)
+RUN {% block path %}{% endblock %} /gramine/app_files/sign.sh \
+      /gramine/app_files/gsc-signer-key.pem \
+      /gramine/app_files/entrypoint.manifest \
+      /gramine/app_files/entrypoint.manifest.sgx \
+      $passphrase
+
+# This trick removes all temporary files from the previous commands (including gsc-signer-key.pem
+# and passphrase)
 FROM {{image}}
 
 COPY --from=unsigned_image /gramine/app_files/*.sig /gramine/app_files/

--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -9,6 +9,7 @@ RUN dnf update -y \
     &&  dnf install -y \
         binutils \
         epel-release \
+        expect \
         openssl \
         protobuf-c-devel \
         python3 \

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -4,6 +4,7 @@
 RUN apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         binutils \
+        expect \
         libcurl4-openssl-dev \
         libprotobuf-c-dev \
         locales \


### PR DESCRIPTION
This PR add some basic security to the gsc sign stage by providing users the option to use a signing key protected by a passphrase.

To test
Generate a key encrypted with a password, for eg
`openssl genrsa -3 -aes128 -passout pass:test@123 -out enclave-key.pem 3072`

Provide the password during the gsc sign step as shown below 
`./gsc sign-image <base-image> enclave-key.pem -p test@123`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/88)
<!-- Reviewable:end -->
