### PR TITLE
Fix GSC gramine base build issue

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -301,6 +301,7 @@ def gsc_build_gramine(args):
               f'`{gramine_image_name}`.')
         return
 
+    shutil.copyfile('keys/intel-sgx-deb.key', tmp_build_path / 'intel-sgx-deb.key')
     build_docker_image(docker_socket.api, tmp_build_path, gramine_image_name, 'Dockerfile.compile',
                        rm=args.rm, nocache=args.no_cache, buildargs=extract_build_args(args))
 


### PR DESCRIPTION
- Copying intel-sgx-deb.key to docker build path was missing in "gsc_build_gramine". Added the key copy to the function.

Signed-off-by: manju956 <manjunath.a.c@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/92)
<!-- Reviewable:end -->
