### PR TITLE
Update documentation to v1.3.1

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -299,8 +299,8 @@ in :file:`config.yaml.template`.
 .. describe:: Distro
 
    Defines Linux distribution to be used to build Gramine in. Currently tested
-   distros are Ubuntu 18.04, Ubuntu 20.04, Ubuntu 21.04 and CentOS 8. Default
-   value is ``ubuntu:18.04``.
+   distros are Ubuntu 18.04, Ubuntu 20.04, Ubuntu 21.04, Debian 10, Debian 11
+   and CentOS 8. Default value is ``ubuntu:18.04``.
 
 .. describe:: Registry
 
@@ -316,7 +316,7 @@ in :file:`config.yaml.template`.
 
 .. describe:: Gramine.Branch
 
-   Use this release/branch of the repository. Default value: ``v1.2``.
+   Use this release/branch of the repository. Default value: ``v1.3.1``.
 
 .. describe:: Gramine.Image
 
@@ -528,12 +528,3 @@ you must manually add them to the manifest::
    sgx.trusted_files = [ "file:file1", "file:file2" ]
    or
    sgx.allowed_files = [ "file:file3", "file:file4" ]
-
-Docker images with non-executables as entrypoint
-------------------------------------------------
-
-Docker images may contain a script entrypoint which is not an ELF executable.
-:program:`gsc` fails to recognize such entrypoints and fails during the image
-build. A workaround relies on creating an image from the application image which
-has an entrypoint of the script interpreter with the script as an argument. This
-allows :program:`gsc` to start the interpreter instead of the script.

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -12,7 +12,7 @@ Registry: ""
 # below; typically, you want to keep the default values though
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "v1.2"
+    Branch:     "v1.3.1"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This also removes a note about unimplemented "scripts as entrypoints" (previously, Gramine only supported binaries as entrypoints). This feature is implemented in Gramine v1.3.1.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/95)
<!-- Reviewable:end -->
