### PR TITLE
Copy Intel key into Docker image during `gsc build-gramine`

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -9,7 +9,11 @@ Distro: "ubuntu:18.04"
 Registry: ""
 
 # If you're using your own fork and branch of Gramine, specify the GitHub link and the branch name
-# below; typically, you want to keep the default values though
+# below; typically, you want to keep the default values though.
+#
+# It is also possible to specify the prebuilt Gramine Docker image (that was built previously via
+# the `gsc build-gramine` command). For this, remove Repository and Branch and instead write:
+#   Image:      "<prebuilt Gramine Docker image>"
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
     Branch:     "v1.3.1"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Copy Intel repo signing key into the resulting base-Gramine Docker image (as part of the `gsc build-gramine` command). This step was missing and resulted in failure of `gsc build-gramine`. Additionally, this commit improves the code quality of the `build-gramine` logic.

Kudos to Manjunath A C (@manju956) who reported this problem and fixed it in https://github.com/gramineproject/gsc/pull/92. My PR supersedes his PR, as I found some additional things to fix/improve during my testing.

## How to test this PR? <!-- (if applicable) -->

- Create `config-prebuilt-image.yaml` that will contain these lines instead of `Gramine.Repository` + `Gramine.Branch`:
```
 Gramine:
    Image: "base-gramine-image"
```

- Now let's test:
```
# download the official Python image for testing
docker pull python

# this first command is just for testing of `-f` flag (creates the Dockerfile only)
./gsc build-gramine -c config.yaml -f base-gramine-image

# now the real Docker images' creation
./gsc build-gramine --rm -c config.yaml base-gramine-image
./gsc build --rm -c config-prebuilt-image.yaml --insecure-args python test/generic.manifest
./gsc sign-image python enclave-key.pem
docker run --device=/dev/sgx_enclave -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket gsc-python -c 'print("HelloWorld!")'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/96)
<!-- Reviewable:end -->
