### PR TITLE
Fix initial message for `gsc sign-image` command

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -339,7 +339,7 @@ def gsc_sign_image(args):
               f'You must first build this image via `gsc build` command.')
         sys.exit(1)
 
-    print(f'Signing graminized Docker image `unsigned_image_name` -> `{signed_image_name}`...')
+    print(f'Signing graminized Docker image `{unsigned_image_name}` -> `{signed_image_name}`...')
 
     # generate Dockerfile.sign from Jinja-style templates/<distro>/Dockerfile.sign.template
     # using the user-provided config file with info on OS distro, Gramine version and SGX driver


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Kudos to Jitender Kumar for finding this typo.

## How to test this PR? <!-- (if applicable) -->

Without this PR:
```bash
$ ./gsc sign-image python enclave-key.pem
Signing graminized Docker image `unsigned_image_name` -> `gsc-python`...
```

With this PR:
```bash
$ ./gsc sign-image python enclave-key.pem
Signing graminized Docker image `gsc-python-unsigned` -> `gsc-python`...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/97)
<!-- Reviewable:end -->
