### PR TITLE
Change ownership of signing script to the default user of the image

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -360,7 +360,7 @@ def gsc_sign_image(args):
     tmp_build_key_path = tmp_build_path / 'gsc-signer-key.pem'
     tmp_build_sign_path = tmp_build_path / 'sign.sh'
     shutil.copyfile(os.path.abspath(args.key), tmp_build_key_path)
-    shutil.copyfile(os.path.abspath('sign.sh'), tmp_build_sign_path)
+    shutil.copy(os.path.abspath('sign.sh'), tmp_build_sign_path)
 
     try:
         # `forcerm` parameter forces removal of intermediate Docker images even after unsuccessful

--- a/templates/Dockerfile.common.sign.template
+++ b/templates/Dockerfile.common.sign.template
@@ -4,7 +4,6 @@ COPY gsc-signer-key.pem /gramine/app_files/gsc-signer-key.pem
 
 ARG passphrase
 COPY sign.sh /gramine/app_files/sign.sh
-RUN chmod +x /gramine/app_files/sign.sh
 
 RUN {% block path %}{% endblock %} /gramine/app_files/sign.sh \
       /gramine/app_files/gsc-signer-key.pem \


### PR DESCRIPTION
Signed-off-by: aneessahib <anees.a.sahib@intel.com>
This PR changes ownership of `sign.sh` to local user before adding execution privilege. Currently signing works only when the default user of the image is root. This should have been factored while developing commit `08add16203c26382b7b57a5503b2a3e2df638f94`

Sankar @svenkata9  ran into this issue while attempting at graminizing `memcached` docker images

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/98)
<!-- Reviewable:end -->
