### PR TITLE
Work around TOML Python parser bug of parsing `\x`

### DIFF
--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -71,6 +71,14 @@ def generate_trusted_files(root_dir, already_added_files):
             if '\n' in filename:
                 # we use TOML's basic single-line strings, can't have newlines
                 continue
+            if '\\x' in filename:
+                # Python TOML parser has a bug that prevents it from correctly handling `\x`
+                # sequences in strings (see https://github.com/uiri/toml/issues/404). Fortunately,
+                # the only files that exhibit such pattern are systemd helper files which graminized
+                # apps will never access anyway. FIXME: Switch to another, less buggy TOML parser.
+                print(f'\t[from inside Docker container] File {filename} contains `\\x` sequence '
+                       'and will be skipped from `sgx.trusted_files`!')
+                continue
 
             trusted_file_entry = f'file:{filename}'
             if trusted_file_entry in already_added_files:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The currently used TOML parser in Python is buggy and doesn't allow to parse filenames like `system-systemd\x2dcryptsetup.slice`. Since the only files that we detected in real world are systemd helper files (which are not used by graminized apps anyway), the current workaround is to simply skip such files when collecting `sgx.trusted_files`.

The bug was already reported by someone else: https://github.com/uiri/toml/issues/404.

The bug was found in https://github.com/gramineproject/gsc/issues/100.

Fixes #100.

## How to test this PR? <!-- (if applicable) -->

Try the workload in #100.

Looks like this:
```
./gsc build --no-cache --insecure-args gcr.io/k8s-minikube/kicbase:v0.0.35 test/generic.manifest
...
Step 26/28 : RUN chmod u+x /gramine/app_files/apploader.sh     && /usr/bin/python3 -B /gramine/app_files/finalize_manifest.py     && rm -f /gramine/app_files/finalize_manifest.py

 ---> Running in 37fb48e07174
        [from inside Docker container] File /usr/lib/systemd/system/system-systemd\x2dcryptsetup.slice contains `\x` sequence and will be skipped from `sgx.trusted_files`!
        [from inside Docker container] Found 20250 files in `/`.
        [from inside Docker container] Successfully finalized `/gramine/app_files/entrypoint.manifest`.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/101)
<!-- Reviewable:end -->
