### PR TITLE
Add `.cache` directory to the exclusion list of trusted_files

### DIFF
--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -33,6 +33,7 @@ def extract_files_from_user_manifest(manifest):
 def generate_trusted_files(root_dir, already_added_files):
     excluded_paths_regex = (r'^/('
                                 r'boot/.*'
+                                r'|\.cache/.*'
                                 r'|\.dockerenv'
                                 r'|\.dockerinit'
                                 r'|dev/.*'


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
A temporary directory `.cache` gets created inside image during GSC build process and GSC tries to add this directory to the list of trusted_files which fails with `permission denied` error. It seems reasonable to exclude this directory from trusted_files list.

## How to test this PR? <!-- (if applicable) -->

graminize `bitnami/scikit-learn-intel` image with GSC

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/103)
<!-- Reviewable:end -->
