### PR TITLE
Move from toml library to `tomli` + `tomli-w`

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -42,7 +42,8 @@ pip. GSC requires Python 3.6 or later.
 .. code-block:: sh
 
    sudo apt-get install docker.io python3 python3-pip
-   pip3 install docker jinja2 toml pyyaml
+   pip3 install docker jinja2 tomli tomli-w pyyaml
+   pip3 install toml  # for compatibility with Gramine v1.3 or lower
 
 SGX software stack
 ------------------

--- a/gsc.py
+++ b/gsc.py
@@ -16,7 +16,8 @@ import tempfile
 
 import docker  # pylint: disable=import-error
 import jinja2
-import toml    # pylint: disable=import-error
+import tomli   # pylint: disable=import-error
+import tomli_w # pylint: disable=import-error
 import yaml    # pylint: disable=import-error
 
 def gsc_image_name(original_image_name):
@@ -214,10 +215,10 @@ def gsc_build(args):
     #   - base Docker image's environment variables
     #   - additional, user-provided manifest options
     entrypoint_manifest_render = env.get_template(f'{distro}/entrypoint.manifest.template').render()
-    entrypoint_manifest_dict = toml.loads(entrypoint_manifest_render)
+    entrypoint_manifest_dict = tomli.loads(entrypoint_manifest_render)
 
     base_image_environment = extract_environment_from_image_config(original_image.attrs['Config'])
-    base_image_dict = toml.loads(base_image_environment)
+    base_image_dict = tomli.loads(base_image_environment)
 
     user_manifest_contents = ''
     if not os.path.exists(args.manifest):
@@ -225,7 +226,7 @@ def gsc_build(args):
     with open(args.manifest, 'r') as user_manifest_file:
         user_manifest_contents = user_manifest_file.read()
 
-    user_manifest_dict = toml.loads(user_manifest_contents)
+    user_manifest_dict = tomli.loads(user_manifest_contents)
 
     # Support deprecated syntax: replace old-style TOML-dict (`sgx.trusted_files.key = "file:foo"`)
     # with new-style TOML-array (`sgx.trusted_files = ["file:foo"]`) in the user manifest
@@ -246,8 +247,8 @@ def gsc_build(args):
     merged_manifest_dict = merge_two_dicts(user_manifest_dict, entrypoint_manifest_dict)
     merged_manifest_dict = merge_two_dicts(merged_manifest_dict, base_image_dict)
 
-    with open(tmp_build_path / 'entrypoint.manifest', 'w') as entrypoint_manifest:
-        toml.dump(merged_manifest_dict, entrypoint_manifest)
+    with open(tmp_build_path / 'entrypoint.manifest', 'wb') as entrypoint_manifest:
+        tomli_w.dump(merged_manifest_dict, entrypoint_manifest)
 
     # copy helper script to finalize the manifest from within graminized Docker image
     shutil.copyfile('finalize_manifest.py', tmp_build_path / 'finalize_manifest.py')
@@ -447,7 +448,7 @@ def gsc_info_image(args):
             print(f'Could not extract Intel SGX-related information from image {args.image}.')
             sys.exit(1)
 
-        print(toml.dumps(sigstruct))
+        print(tomli_w.dumps(sigstruct))
 
 
 argparser = argparse.ArgumentParser()

--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -16,7 +16,11 @@ RUN dnf update -y \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
-    && /usr/bin/python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
+    && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
+                                          'tomli>=1.1.0' 'tomli-w>=0.4.0'
+
+# For compatibility with Gramine v1.3 or lower
+RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
 
 # Install pyelftools after the installation of epel-release as it is provided by the EPEL repo
 RUN dnf install -y python3-pyelftools

--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -36,5 +36,9 @@ RUN dnf update -y \
         python3-protobuf \
         rpm-build \
         wget \
-    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.56'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56'
+
+# For compatibility with Gramine v1.3 or lower
+RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
+
 {% endblock %}

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -15,7 +15,11 @@ RUN apt-get update \
         python3-pip \
         python3-protobuf \
         python3-pyelftools \
-    && /usr/bin/python3 -B -m pip install click jinja2 protobuf 'toml>=0.10'
+    && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
+                                          'tomli>=1.1.0' 'tomli-w>=0.4.0'
+
+# For compatibility with Gramine v1.3 or lower
+RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
 
 {% if debug %}
 RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -23,7 +23,10 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         python3-pip \
         python3-protobuf \
         wget \
-    && /usr/bin/python3 -B -m pip install 'toml>=0.10' 'meson>=0.56'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56'
+
+# For compatibility with Gramine v1.3 or lower
+RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
 
 COPY intel-sgx-deb.key /
 

--- a/test/generic.manifest
+++ b/test/generic.manifest
@@ -4,6 +4,9 @@ loader.pal_internal_mem_size = "128M"
 sgx.enclave_size = "4G"
 sgx.thread_num = 8
 
+# FIXME: `toml` Python lib that was used in Gramine v1.3 and lower hangs/fails on non-homogeneous
+#        TOML arrays, so until we fully deprecate support for Gramine v1.3 in GSC, specify items in
+#        the sgx.trusted_files array only as strings (never as dicts `{ "uri": "file:file1" }`)
 sgx.trusted_files = [
   "file:/gramine/app_files/entrypoint.manifest",  # unused entry, only to test merging of manifests
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`toml` Python library (for parsing and dumping TOML files) is buggy and doesn't support the full spec of TOML 1.0.0. This commit replaces it with more robust `tomli` (for parsing) and `tomli-w` (for dumping).

Note that GSC supports both newer versions of Gramine (that also use `tomli`) and older versions of Gramine (that use `toml`).

This PR is a counterpart to https://github.com/gramineproject/gramine/pull/995, but is independent from it: GSC can work with new and old Gramine anyway.

## How to test this PR? <!-- (if applicable) -->

Try e.g. Python example. Both `Branch: "v1.3.1"` and `Branch: "dimakuv/python-tomli"` (from https://github.com/gramineproject/gramine/pull/995) in `config.yaml` should work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/106)
<!-- Reviewable:end -->
