### PR TITLE
Remove `$HOME/.cache` dir before collecting image files

### DIFF
--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -20,8 +20,14 @@ RUN mkdir -p /gramine/app_files
 # Make the app image user owner of /gramine/app_files directory
 RUN chown {{app_user}} /gramine/app_files/
 
+# Remove root-user cached files if any (may have been created during install step above)
+RUN rm -rf $HOME/.cache
+
 # Switch back to original app_image user
 USER {{app_user}}
+
+# Remove original-user cached files if any (some images have unclean state)
+RUN rm -rf $HOME/.cache
 
 # Copy path-specific installation of Gramine
 {% if debug %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Installation of packages during GSC's build step may create files under `$HOME/.cache`. Also, some original Docker images may have unclean state with these files not removed. To prevent `finalize_manifest.py` from collecting these files for the `sgx.trusted_files` list, we remove them in the intermediate GSC image.

Closes #103. (Previous attempt at fixing it).

Kudos to @jkr0103 who found this bug and suggested a first attempt at fixing it.

Kudos to @woju who suggested the current fix.

## How to test this PR? <!-- (if applicable) -->

Tested with:
- `python` (just for sanity)
- `bitnami/scikit-learn-intel` (fails without this PR) like this:
```
  File "/gramine/meson_build_output/lib/python3.8/site-packages/graminelibos/manifest.py", line 29, in hash_file_contents
    with open(path, 'rb') as f:
PermissionError: [Errno 13] Permission denied: '/.cache/pip/http/8/a/c/4/d/8ac4d14dc45e27d21da49fb515570b6f875b78707de9b08ce1088d1b'
```