### PR TITLE
Add support for production signing with Azure Key Vault

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/expect
 spawn gramine-sgx-sign \
-      --key [lindex $argv 0] \
-      --manifest [lindex $argv 1] \
-      --output [lindex $argv 2]
+      --keytype [lindex $argv 0] \
+      --key [lindex $argv 1] \
+      --manifest [lindex $argv 2] \
+      --output [lindex $argv 3]
 
 set timeout -1
 set times 0
@@ -11,7 +12,7 @@ expect "Enter pass phrase for [lindex $argv 0]" {
     if {$times > $maxtimes} {
         exit 0
     }
-    send "[lindex $argv 3]\r"
+    send "[lindex $argv 4]\r"
     set times [ expr $times + 1];
     exp_continue
 }

--- a/templates/Dockerfile.common.sign.akv.template
+++ b/templates/Dockerfile.common.sign.akv.template
@@ -1,15 +1,25 @@
 # Sign image in a separate stage to ensure that signing key is never part of the final image
 FROM {{image}} as unsigned_image
-COPY gsc-signer-key.pem /gramine/app_files/gsc-signer-key.pem
 
-ARG passphrase
+ARG key
 COPY sign.sh /gramine/app_files/sign.sh
 
+{% block install %}
+RUN apt-get update \
+        && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        curl \
+     && /usr/bin/python3 -B -m pip install azure-keyvault-keys azure-identity
+
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+RUN az login
+
+#/gramine/app_files/{{key}} \
 RUN {% block path %}{% endblock %} /gramine/app_files/sign.sh \
-      /gramine/app_files/gsc-signer-key.pem \
+      akv \
+      $key \
       /gramine/app_files/entrypoint.manifest \
-      /gramine/app_files/entrypoint.manifest.sgx \
-      $passphrase
+      /gramine/app_files/entrypoint.manifest.sgx
+{% endblock %}
 
 # This trick removes all temporary files from the previous commands (including gsc-signer-key.pem
 # and passphrase)

--- a/templates/Dockerfile.common.sign.local.template
+++ b/templates/Dockerfile.common.sign.local.template
@@ -1,0 +1,20 @@
+# Sign image in a separate stage to ensure that signing key is never part of the final image
+FROM {{image}} as unsigned_image
+COPY gsc-signer-key.pem /gramine/app_files/gsc-signer-key.pem
+
+ARG passphrase
+COPY sign.sh /gramine/app_files/sign.sh
+
+RUN {% block path %}{% endblock %} /gramine/app_files/sign.sh \
+      pem \
+      /gramine/app_files/gsc-signer-key.pem \
+      /gramine/app_files/entrypoint.manifest \
+      /gramine/app_files/entrypoint.manifest.sgx \
+      $passphrase
+
+# This trick removes all temporary files from the previous commands (including gsc-signer-key.pem
+# and passphrase)
+FROM {{image}}
+
+COPY --from=unsigned_image /gramine/app_files/*.sig /gramine/app_files/
+COPY --from=unsigned_image /gramine/app_files/*.sgx /gramine/app_files/

--- a/templates/centos/Dockerfile.sign.akv.template
+++ b/templates/centos/Dockerfile.sign.akv.template
@@ -1,0 +1,3 @@
+{% extends "Dockerfile.common.sign.akv.template" %}
+
+{% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib64 -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/centos/Dockerfile.sign.local.template
+++ b/templates/centos/Dockerfile.sign.local.template
@@ -1,3 +1,3 @@
-{% extends "Dockerfile.common.sign.template" %}
+{% extends "Dockerfile.common.sign.local.template" %}
 
 {% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib64 -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/debian/Dockerfile.sign.akv.template
+++ b/templates/debian/Dockerfile.sign.akv.template
@@ -1,0 +1,3 @@
+{% extends "Dockerfile.common.sign.akv.template" %}
+
+{% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/debian/Dockerfile.sign.local.template
+++ b/templates/debian/Dockerfile.sign.local.template
@@ -1,3 +1,3 @@
-{% extends "Dockerfile.common.sign.template" %}
+{% extends "Dockerfile.common.sign.local.template" %}
 
 {% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/ubuntu/Dockerfile.sign.akv.template
+++ b/templates/ubuntu/Dockerfile.sign.akv.template
@@ -1,0 +1,1 @@
+{% extends "debian/Dockerfile.sign.akv.template" %}

--- a/templates/ubuntu/Dockerfile.sign.local.template
+++ b/templates/ubuntu/Dockerfile.sign.local.template
@@ -1,0 +1,1 @@
+{% extends "debian/Dockerfile.sign.local.template" %}

--- a/templates/ubuntu/Dockerfile.sign.template
+++ b/templates/ubuntu/Dockerfile.sign.template
@@ -1,1 +1,0 @@
-{% extends "debian/Dockerfile.sign.template" %}


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This change enables production signing with Azure Key Vault's Managed HSM. The `gsc.py` script is modified to take a `keytype` parameter that will use `pem` for local private key and `akv` for Azure Key Vault.

Please also see https://github.com/gramineproject/gramine/pull/1020 for the changes to `gramine-sgx-sign`

This change replaces the Dockerfile template used for signing with two different templates - one for local signing (default) and the other one for signing with Azure Key Vault.

In case of Azure Key Vault, we currently enable signing only for login with az-cli. So, the corresponding Dockerfile installs the AKV related packages and invokes `az login`. This will prompt an authentication during the signing stage and will wait until the authentication succeeds (or fails) - please see below. (This will be revisited later once we have managed identity working with Azure subscription).

![image](https://user-images.githubusercontent.com/29835993/199432088-9dd3c007-e3e5-4b59-a227-cc1ab16f6bc2.png)

Related issues in Gramine:
- https://github.com/gramineproject/gramine/issues/11
- https://github.com/gramineproject/gramine/issues/698

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Please apply https://github.com/gramineproject/gramine/pull/1020 and build Gramine with the corresponding changes. And, run `./gsc sign-image --keytype akv --key vault_url:keyname <unsigned gramine image>` to test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/108)
<!-- Reviewable:end -->
