### PR TITLE
Drop support for out-of-tree DCAP SGX drivers

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -21,17 +21,17 @@ Gramine:
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:
 #
+#   - upstream (in-kernel) driver: use empty values like below
+#         Repository: ""
+#         Branch:     ""
+#
+#   - DCAP out-of-tree driver: same as above, use empty values
+#         Repository: ""
+#         Branch:     ""
+#
 #   - legacy out-of-tree driver: use something like the below values, but adjust the branch name
 #         Repository: "https://github.com/01org/linux-sgx-driver.git"
 #         Branch:     "sgx_driver_1.9"
-#
-#   - DCAP out-of-tree driver: use something like the below values
-#         Repository: "https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
-#         Branch:     "DCAP_1.11 && cp -r driver/linux/* ."
-#
-#   - DCAP in-kernel driver: use empty values like below
-#         Repository: ""
-#         Branch:     ""
 #
 SGXDriver:
     Repository: ""

--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -13,7 +13,7 @@ RUN cd /gramine \
     && git fetch origin {{Gramine.Branch}} \
     && git checkout {{Gramine.Branch}}
 
-{% if SGXDriver.Repository %}
+{% if "linux-sgx-driver" in SGXDriver.Repository %}
 RUN cd /gramine \
     && git clone {{SGXDriver.Repository}} driver \
     && cd driver \
@@ -31,9 +31,7 @@ RUN cd /gramine \
        --buildtype={% if debug %}debug{% else %}release{% endif %} \
        -Ddirect=enabled -Dsgx=enabled \
        {% if Distro.startswith('ubuntu') %}-Ddcap=enabled{% endif %} \
-       {% if "SGXDataCenterAttestationPrimitives" in SGXDriver.Repository %} \
-       -Dsgx_driver=dcap1.10 -Dsgx_driver_include_path=/gramine/driver/driver/linux/include \
-       {% elif "linux-sgx-driver" in SGXDriver.Repository %} \
+       {% if "linux-sgx-driver" in SGXDriver.Repository %} \
        -Dsgx_driver=oot -Dsgx_driver_include_path=/gramine/driver \
        {% else %} \
        -Dsgx_driver=upstream -Dsgx_driver_include_path=/gramine/driver \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The out-of-tree DCAP drivers have the same userspace interface as the upstream driver, so we can re-use the flow for upstream one.

This is a counterpart PR to these ones for core Gramine:
- https://github.com/gramineproject/gramine/pull/997
- https://github.com/gramineproject/gramine/pull/1027

Note that GSC will still be able to run with older Gramine (e.g. v1.3.1). This is because GSC now uses `-Dsgx_driver=upstream`, so older Gramine will recognize this.

**Note that the reverse is false**: one cannot use old GSC (before this PR) with the new Gramine, if the system has an oot DCAP driver -- in this case GSC will set `Dsgx_driver=dcap1.10` which is not known to new Gramine.

Finally, note that if GSC is used with an old `config.yaml` file with something like:
```
SGXDriver:
    Repository: "https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
    Branch:     "DCAP_1.10.3 && cp -r driver/linux/* ."
```
this will still work, because GSC will simply ignore this (oot DCAP driver) repo and default to `upstream`.

## How to test this PR? <!-- (if applicable) -->

Manually on different machines with different `config.yaml` configs: different `SGXDriver` and different `Gramine.Branch`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/109)
<!-- Reviewable:end -->
