### PR TITLE
Enable `--template` option to use with sign-image (for use with HSMs,for example)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __pycache__
 *.manifest.sgx
 *.sig
 *.token
+/templates/Dockerfile.sign.user.template

--- a/gsc.py
+++ b/gsc.py
@@ -350,26 +350,36 @@ def gsc_sign_image(args):
 
     distro, _ = distro.split(':')
     env.loader = jinja2.FileSystemLoader('templates/')
-    sign_template = env.get_template(f'{distro}/Dockerfile.sign.template')
+    sign_template = []
+    build_args = []
 
     os.makedirs(tmp_build_path, exist_ok=True)
+
+    # Use default steps if user has not provided a Dockerfile/template for signing
+    if args.template is None:
+        # copy user-provided signing key and signing Bash script to our tmp build dir (to copy them
+        # later inside Docker image)
+        tmp_build_key_path = tmp_build_path / 'gsc-signer-key.pem'
+        tmp_build_sign_path = tmp_build_path / 'sign.sh'
+        shutil.copyfile(os.path.abspath(args.key), tmp_build_key_path)
+        shutil.copy(os.path.abspath('sign.sh'), tmp_build_sign_path)
+        sign_template = env.get_template(f'{distro}/Dockerfile.sign.template')
+        build_args = {"passphrase": args.passphrase}
+    else:
+        shutil.copy(args.template, 'templates/Dockerfile.sign.user.template')
+        sign_template = env.get_template(f'{distro}/Dockerfile.sign.user.template')
+
     with open(tmp_build_path / 'Dockerfile.sign', 'w') as dockerfile:
         dockerfile.write(sign_template.render(image=unsigned_image_name))
-
-    # copy user-provided signing key and signing Bash script to our tmp build dir (to copy them
-    # later inside Docker image)
-    tmp_build_key_path = tmp_build_path / 'gsc-signer-key.pem'
-    tmp_build_sign_path = tmp_build_path / 'sign.sh'
-    shutil.copyfile(os.path.abspath(args.key), tmp_build_key_path)
-    shutil.copy(os.path.abspath('sign.sh'), tmp_build_sign_path)
 
     try:
         # `forcerm` parameter forces removal of intermediate Docker images even after unsuccessful
         # builds, to not leave the signing key lingering in any Docker containers
         build_docker_image(docker_socket.api, tmp_build_path, signed_image_name, 'Dockerfile.sign',
-                           forcerm=True, buildargs={"passphrase": args.passphrase})
+                           forcerm=True, buildargs=build_args)
     finally:
-        os.remove(tmp_build_key_path)
+        if args.template is None:
+            os.remove(tmp_build_key_path)
 
     if get_docker_image(docker_socket, signed_image_name) is None:
         print(f'Failed to build a signed graminized Docker image `{signed_image_name}`.')
@@ -501,7 +511,9 @@ sub_sign.set_defaults(command=gsc_sign_image)
 sub_sign.add_argument('-c', '--config_file', type=argparse.FileType('r', encoding='UTF-8'),
     default='config.yaml', help='Specify configuration file.')
 sub_sign.add_argument('image', help='Name of the application (base) Docker image.')
-sub_sign.add_argument('key', help='Key to sign the Intel SGX enclaves inside the Docker image.')
+sub_sign.add_argument('-k', '--key', help='Key to sign the Intel SGX enclaves inside the Docker image.')
+sub_sign.add_argument('-t', '--template',
+                      help='Custom Dockerfile/template to use for signing, say, with a HSM.')
 sub_sign.add_argument('-p', '--passphrase', help='Passphrase for the signing key.')
 
 sub_info = subcommands.add_parser('info-image', help='Retrieve information about a graminized '

--- a/templates/centos/Dockerfile.sign.user.template
+++ b/templates/centos/Dockerfile.sign.user.template
@@ -1,0 +1,3 @@
+{% extends "Dockerfile.sign.user.template" %}
+
+{% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib64 -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/debian/Dockerfile.sign.user.template
+++ b/templates/debian/Dockerfile.sign.user.template
@@ -1,0 +1,3 @@
+{% extends "Dockerfile.sign.user.template" %}
+
+{% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/ubuntu/Dockerfile.sign.user.template
+++ b/templates/ubuntu/Dockerfile.sign.user.template
@@ -1,0 +1,2 @@
+{% extends "debian/Dockerfile.sign.user.template" %}
+


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description
The `gsc` tool cannot do production signing on the gramized docker images today, and this PR enables that. This PR enables passing a 'self-contained' Dockerfile as an argument to `gsc sign-image` with the option `--template` (newly introduced in this PR).  For example, using a template like [this ](https://github.com/svenkata9/contrib/blob/svenkat9/akv_sign/Integrations/azure/akv-sign/Dockerfile.sign.akv.debian.template), we can do production signing with Azure Key Vault. Once this PR is merged, `contrib` repo will be updated with templates for Azure Key Vault and OpenSSL engine.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
For testing this PR, you will need to use the Dockerfile template mentioned above for use with AKV, or create one based on this for using local signing. and then you will be able to sign the unsigned gsc image using `./gsc sign-image --template Dockerfile.sign.akv.debian.template`

