### PR TITLE
Skip adding empty instruction `CMD [""]` and fix escaping

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -16,6 +16,7 @@ import tempfile
 
 import docker  # pylint: disable=import-error
 import jinja2
+import shlex
 import tomli   # pylint: disable=import-error
 import tomli_w # pylint: disable=import-error
 import yaml    # pylint: disable=import-error
@@ -76,9 +77,7 @@ def extract_binary_info_from_image_config(config, env):
     # Check if we have fixed binary arguments as part of entrypoint
     if num_starting_entrypoint_items > 1:
         last_bin_arg = num_starting_entrypoint_items
-        escaped_args = [s.replace('\\', '\\\\').replace('"', '\\"')
-                        for s in entrypoint[1:last_bin_arg]]
-        binary_arguments = '"' + '" "'.join(escaped_args) + '"'
+        binary_arguments = entrypoint[1:last_bin_arg]
     else:
         last_bin_arg = 0
         binary_arguments = ''
@@ -86,7 +85,6 @@ def extract_binary_info_from_image_config(config, env):
     # Place the remaining optional arguments previously specified as command in the new command.
     # Necessary since the first element of the command may be the binary of the resulting image.
     cmd = entrypoint[last_bin_arg + 1:] if len(entrypoint) > last_bin_arg + 1 else ''
-    cmd = [s.replace('\\', '\\\\').replace('"', '\\"') for s in cmd]
 
     env.globals.update({
         'binary': binary,
@@ -185,6 +183,7 @@ def gsc_build(args):
 
     # initialize Jinja env with configurations extracted from the original Docker image
     env = jinja2.Environment()
+    env.filters['shlex_quote'] = shlex.quote
     env.globals.update(config)
     env.globals.update(vars(args))
     env.globals.update({'app_image': original_image_name})

--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -44,7 +44,9 @@ COPY --chown={{app_user}} entrypoint.manifest /gramine/app_files/
 # Generate trusted arguments if required
 {% if not insecure_args %}
 RUN /gramine/meson_build_output/bin/gramine-argv-serializer \
-        /gramine/app_files/{{binary_basename}} {{binary_arguments}} "{{"\" \"".join(cmd)}}" > /gramine/app_files/trusted_argv
+        /gramine/app_files/{{binary_basename}} \
+        {{ binary_arguments | map('shlex_quote') | join(' ') }} \
+        {{ cmd | map('shlex_quote') | join(' ') }} > /gramine/app_files/trusted_argv
 {% endif %}
 
 # Docker entrypoint/cmd typically contains only the basename of the executable so create a symlink
@@ -61,4 +63,4 @@ RUN chmod u+x /gramine/app_files/apploader.sh \
 
 # Define default command
 ENTRYPOINT ["/bin/bash", "/gramine/app_files/apploader.sh"]
-CMD [{% if insecure_args %} "{{'", "'.join(cmd)}}" {% endif %}]
+{% if insecure_args and cmd %}CMD {{ cmd | tojson }}{% endif %}

--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -14,7 +14,9 @@ then
     gramine-sgx-get-token --quiet \
         --sig /gramine/app_files/entrypoint.sig --output /gramine/app_files/entrypoint.token
     gramine-sgx /gramine/app_files/entrypoint \
-        {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
+        {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
+        "${@}"{% endif %}
 else
-    gramine-direct /gramine/app_files/entrypoint {{binary_arguments}} "${@}"
+    gramine-direct /gramine/app_files/entrypoint \
+    {{ binary_arguments | map('shlex_quote') | join(' ') }} "${@}"
 fi

--- a/test/ubuntu18.04-hello-world.dockerfile
+++ b/test/ubuntu18.04-hello-world.dockerfile
@@ -2,4 +2,4 @@ From ubuntu:18.04
 
 RUN apt-get update
 
-CMD ["echo", "\"Hello World!\""]
+CMD ["echo", "\"Hello World! Let's check escaped symbols: < & > \""]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Change in this PR is to skip adding CMD instruction if there are no arguments to CMD in `Docker.build` file.
This fixes the issue as described in PR https://github.com/gramineproject/contrib/pull/21

I also tried the fix suggested by Woju in https://github.com/gramineproject/contrib/pull/21
It seems those filters are not available with jinja.

Another filter I tried is `tojson` like this: `{% if insecure_args and cmd %} CMD {{ cmd | tojson }} {% endif %}` but that doesn't give exactly same output as per original CMD:
CMD in base image: `CMD ["--protected-mode", "no", "--save", "''"]`
CMD in gsc/build/xxx/Dockerfile.build: `CMD ["--protected-mode", "no", "--save", "\u0027\u0027"]`

GSC output after building GSC without `--insecure-args`, i.e. putting args securely in `trusted_argsv` file:

*** FATAL CONFIG FILE ERROR (Redis 7.0.5) ***
Reading the configuration file, at line 3

'save "\u0027\u0027"'
Invalid save parameters

## How to test this PR? <!-- (if applicable) -->
Create GSC image from a base image with/without CMD instructions and verity `gsc/build/image_name/Docker.build ` file. It should have CMD instructions if base image have CMD instruction with arguments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/113)
<!-- Reviewable:end -->
