### PR TITLE
Update Gramine Branch in config.yaml.template

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -14,9 +14,12 @@ Registry: ""
 # It is also possible to specify the prebuilt Gramine Docker image (that was built previously via
 # the `gsc build-gramine` command). For this, remove Repository and Branch and instead write:
 #   Image:      "<prebuilt Gramine Docker image>"
+#
+# GSC releases are guaranteed to work with corresponding Gramine releases (and GSC `master`
+# branch is guaranteed to work with current Gramine `master` branch).
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "v1.3.1"
+    Branch:     "master"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:


### PR DESCRIPTION
GSC Master is not compatible with Gramine v1.3.1. We must either use GSC v1.3.1 and Gramine v1.3.1, or both on master

Fixes #115

Signed-off-by: Anjali Rai <anjali.rai@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/117)
<!-- Reviewable:end -->
