### PR TITLE
Update positional arguments `manifest` and `key` to optional arguments

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -85,7 +85,7 @@ Builds an unsigned graminized Docker image of an application image called
 ``gsc-<IMAGE-NAME>-unsigned`` by compiling Gramine or relying on a prebuilt
 Gramine image.
 
-:command:`gsc build` [*OPTIONS*] <*IMAGE-NAME*> <*APP.MANIFEST*>
+:command:`gsc build` [*OPTIONS*] <*IMAGE-NAME*>
 
 .. option:: -d
 
@@ -121,13 +121,13 @@ Gramine image.
 
    Specify configuration file. Default: :file:`config.yaml`.
 
+.. option:: -m
+
+   Manifest file (Gramine configuration).
+
 .. option:: IMAGE-NAME
 
    Name of the application Docker image.
-
-.. option:: APP.MANIFEST
-
-   Manifest file (Gramine configuration).
 
 .. program:: gsc-sign-image
 
@@ -139,11 +139,15 @@ Docker image called ``gsc-<IMAGE-NAME>``. :command:`gsc sign-image` always
 removes intermediate Docker images, if successful or not, to ensure the removal
 of the signing key in them.
 
-:command:`gsc sign-image` [*OPTIONS*] <*IMAGE-NAME*> <*KEY-FILE*>
+:command:`gsc sign-image` [*OPTIONS*] <*IMAGE-NAME*>
 
 .. option:: -c
 
    Specify configuration file. Default: :file:`config.yaml`
+
+.. option:: -k
+
+   Used to sign the Intel SGX enclave
 
 .. option:: -p
 
@@ -152,10 +156,6 @@ of the signing key in them.
 .. option:: IMAGE-NAME
 
    Name of the application Docker image
-
-.. option:: KEY-FILE
-
-   Used to sign the Intel SGX enclave
 
 .. program:: gsc-build-gramine
 
@@ -437,13 +437,13 @@ This example assumes that all prerequisites are installed and configured.
 
    .. code-block:: sh
 
-      ./gsc build --insecure-args python test/generic.manifest
+      ./gsc build --insecure-args --manifest test/generic.manifest python
 
 #. Sign the graminized Docker image using :command:`gsc sign-image`:
 
    .. code-block:: sh
 
-      ./gsc sign-image python enclave-key.pem
+      ./gsc sign-image --key enclave-key.pem python
 
 #. Retrieve SGX-related information from graminized image using :command:`gsc info-image`:
 

--- a/Examples/openvino/README.md
+++ b/Examples/openvino/README.md
@@ -16,13 +16,14 @@ docker build --tag ubuntu20.04-openvino --file ubuntu20.04-openvino.dockerfile .
 2. Graminize the Docker image using `gsc build`:
 ```bash
 cd ../..
-./gsc build --insecure-args ubuntu20.04-openvino \
-    Examples/openvino/ubuntu20.04-openvino.manifest
+./gsc build --insecure-args \
+    --manifest Examples/openvino/ubuntu20.04-openvino.manifest \
+    ubuntu20.04-openvino
 ```
 
 3. Sign the graminized Docker image using `gsc sign-image`:
 ```bash
-./gsc sign-image ubuntu20.04-openvino enclave-key.pem
+./gsc sign-image --key enclave-key.pem ubuntu20.04-openvino
 ```
 
 ## Running the benchmark in GSC

--- a/gsc.py
+++ b/gsc.py
@@ -472,8 +472,8 @@ sub_build.add_argument('--build-arg', action='append', default=[],
     help='Set build-time variables (same as "docker build --build-arg").')
 sub_build.add_argument('-c', '--config_file', type=argparse.FileType('r', encoding='UTF-8'),
     default='config.yaml', help='Specify configuration file.')
+sub_build.add_argument('-m', '--manifest', help='Manifest file to use.');
 sub_build.add_argument('image', help='Name of the application Docker image.')
-sub_build.add_argument('manifest', help='Manifest file to use.')
 
 sub_build_gramine = subcommands.add_parser('build-gramine',
     help='Build base-Gramine Docker image')
@@ -501,7 +501,8 @@ sub_sign.set_defaults(command=gsc_sign_image)
 sub_sign.add_argument('-c', '--config_file', type=argparse.FileType('r', encoding='UTF-8'),
     default='config.yaml', help='Specify configuration file.')
 sub_sign.add_argument('image', help='Name of the application (base) Docker image.')
-sub_sign.add_argument('key', help='Key to sign the Intel SGX enclaves inside the Docker image.')
+sub_sign.add_argument('-k', '--key',
+    help='Key to sign the Intel SGX enclaves inside the Docker image.')
 sub_sign.add_argument('-p', '--passphrase', help='Passphrase for the signing key.')
 
 sub_info = subcommands.add_parser('info-image', help='Retrieve information about a graminized '

--- a/test/README.rst
+++ b/test/README.rst
@@ -32,8 +32,9 @@ below commands assume that you already created the GSC configuration file
 
    docker build --tag ubuntu18.04-bash --file test/ubuntu18.04-bash.dockerfile .
 
-   ./gsc build --insecure-args ubuntu18.04-bash test/ubuntu18.04-bash.manifest
-   ./gsc sign-image ubuntu18.04-bash enclave-key.pem
+   ./gsc build --insecure-args --manifest test/ubuntu18.04-bash.manifest \
+        ubuntu18.04-bash
+   ./gsc sign-image --key enclave-key.pem ubuntu18.04-bash
    ./gsc info-image gsc-ubuntu18.04-bash
 
 Test the graminized Docker image (change ``--device=/dev/sgx_enclave`` to your


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR changes the positional arguments `manifest` and `key` that `gsc build` and `gsc sign-image` commands take respectively to optional ones. This change is being done separately now to accommodate change for production signing #112 (to avoid introducing the breaking change for `key` as optional argument)
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
```
docker pull python
./gsc build -L --manifest test/generic.manifest python
./gsc sign-image -k enclave-key.pem python
```

and run the resulting gsc-python image.