### PR TITLE
Add remark on `sys.enable_extra_runtime_domain_names_conf` in docs

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -529,3 +529,14 @@ you must manually add them to the manifest::
    sgx.trusted_files = [ "file:file1", "file:file2" ]
    or
    sgx.allowed_files = [ "file:file3", "file:file4" ]
+
+Issues with hostname and DNS
+----------------------------
+
+If your application queries the hostname or DNS information, you must manually
+add the following option to the manifest::
+
+    sys.enable_extra_runtime_domain_names_conf = true
+
+For more information on this option, refer to
+https://gramine.readthedocs.io/en/stable/manifest-syntax.html#domain-names-configuration.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

I wasn't sure if we want to enable this option by default for all GSC-produced images (i.e. adding a line here: https://github.com/gramineproject/gsc/blob/master/templates/entrypoint.common.manifest.template).

So I opted for adding a note in our docs.

See #39 for context.

## How to test this PR? <!-- (if applicable) -->

ReadTheDocs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/122)
<!-- Reviewable:end -->
