### PR TITLE
Remove `gramine-sgx-get-token` invocation

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -266,10 +266,11 @@ follows three main stages and produces an image named ``gsc-<image-name>``.
    vary across different deployment machines. GSC combines these variables and
    list of trusted files into a new manifest file. In a last step the entrypoint
    is changed to launch the :file:`apploader.sh` script which generates an Intel
-   SGX token and starts the :program:`gramine-sgx` loader. Note that the
-   generated image (``gsc-<image-name>-unsigned``) cannot successfully load an
-   Intel SGX enclave, since essential files and the signature of the enclave are
-   still missing (see next stage).
+   SGX token (only if needed, on non-FLC platforms) and starts the
+   :program:`gramine-sgx` loader. Note that the generated image
+   (``gsc-<image-name>-unsigned``) cannot successfully load an Intel SGX
+   enclave, since essential files and the signature of the enclave are still
+   missing (see next stage).
 
 #. **Signing the Intel SGX enclave.** The third stage uses Gramine's signer
    tool to generate SIGSTRUCT files for SGX enclave initialization. This tool

--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -11,8 +11,6 @@ set -e
 # Default to Linux-SGX if no PAL was specified
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
-    gramine-sgx-get-token --quiet \
-        --sig /gramine/app_files/entrypoint.sig --output /gramine/app_files/entrypoint.token
     gramine-sgx /gramine/app_files/entrypoint \
         {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
         "${@}"{% endif %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine v1.4 deprecates its explicit usage. If needed, `gramine-sgx` gets the token automatically.

## How to test this PR? <!-- (if applicable) -->

Manually run and check there is no warning about `gramine-sgx-get-token` deprecation anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/127)
<!-- Reviewable:end -->
