### PR TITLE
DONTMERGE Fix `excluded_paths_regex` in `finalize_manifest.py`

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -257,24 +257,22 @@ follows three main stages and produces an image named ``gsc-<image-name>``.
 #. **Graminizing the application image.** The second stage copies the important
    Gramine artifacts (e.g., the runtime and signer tool) from the first stage
    (or if the first stage was skipped, it pulls a prebuilt Docker image defined
-   via the configuration file).  It then prepares image-specific variables such
+   via the configuration file). It then prepares image-specific variables such
    as the executable path and the library path, and scans the entire image to
-   generate a list of trusted files.  GSC excludes files and paths starting with
-   :file:`/boot`, :file:`/dev`, :file:`.dockerenv`, :file:`.dockerinit`,
-   :file:`/etc/mtab`, :file:`/etc/rc`, :file:`/proc`, :file:`/sys`, and
-   :file:`/var`, since checksums are required which either don't exist or may
-   vary across different deployment machines. GSC combines these variables and
-   list of trusted files into a new manifest file. In a last step the entrypoint
-   is changed to launch the :file:`apploader.sh` script which generates an Intel
-   SGX token (only if needed, on non-FLC platforms) and starts the
-   :program:`gramine-sgx` loader. Note that the generated image
-   (``gsc-<image-name>-unsigned``) cannot successfully load an Intel SGX
-   enclave, since essential files and the signature of the enclave are still
-   missing (see next stage).
+   generate a list of trusted files. GSC excludes some system files and paths
+   (for the exact list, see :ref:`excluded-paths`), since checksums are required
+   which either don't exist or may vary across different deployment machines.
+   GSC combines these variables and list of trusted files into a new manifest
+   file. In a last step the entrypoint is changed to launch the
+   :file:`apploader.sh` script which generates an Intel SGX token (only if
+   needed, on non-FLC platforms) and starts the :program:`gramine-sgx` loader.
+   Note that the generated image (``gsc-<image-name>-unsigned``) cannot
+   successfully load an Intel SGX enclave, since essential files and the
+   signature of the enclave are still missing (see next stage).
 
 #. **Signing the Intel SGX enclave.** The third stage uses Gramine's signer
    tool to generate SIGSTRUCT files for SGX enclave initialization. This tool
-   also generates an SGX-specific manifest file.  The required signing key is
+   also generates an SGX-specific manifest file. The required signing key is
    provided by the user via the :command:`gsc sign-image` command and copied
    into this Docker build stage. The generated image is called
    ``gsc-<image-name>`` and includes all necessary files to start an Intel SGX
@@ -518,14 +516,35 @@ either in environment variables or mounted as files. GSC is currently unaware of
 such files and hence, cannot mark them trusted. Similar to trusted data, these
 files may be added to the manifest.
 
+.. _excluded-paths:
+
 Access to files in excluded paths
 ---------------------------------
 
-The manifest generation excludes all files and paths starting with :file:`/boot`
-, :file:`/dev`, :file:`.dockerenv`, :file:`.dockerinit`, :file:`/etc/mtab`,
-:file:`/etc/rc`, :file:`/proc`, :file:`/sys`, and :file:`/var` from the list of
-trusted files. If your application relies on some files in these directories,
-you must manually add them to the manifest::
+The manifest generation excludes the following files and paths from the list of
+trusted files:
+
+- :file:`/boot/*`
+- :file:`/dev/*`
+- :file:`/efi/*`
+- :file:`/media/*`
+- :file:`/mnt/*`
+- :file:`/proc/*`
+- :file:`/run/*`
+- :file:`/sys/*`
+- :file:`/tmp/*`
+- :file:`/var/*`
+- security-critical files under :file:`/etc/`:
+
+  - :file:`/etc/.pwd.lock`
+  - :file:`/etc/gshadow`
+  - :file:`/etc/mtab`
+  - :file:`/etc/rc*`
+  - :file:`/etc/security`
+  - :file:`/etc/shadow`
+
+If your application relies on some files in these directories, you must manually
+add them to the manifest::
 
    sgx.trusted_files = [ "file:file1", "file:file2" ]
    or

--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -32,21 +32,27 @@ def extract_files_from_user_manifest(manifest):
 
 
 def generate_trusted_files(root_dir, already_added_files):
+    # please keep this list in sync with the one in GSC documentation
     excluded_paths_regex = (r'^/('
-                                r'boot/.*'
-                                r'|\.dockerenv'
-                                r'|\.dockerinit'
+                                r'|boot/.*'
                                 r'|dev/.*'
+                                r'|efi/.*'
+                                # below files are security-critical (only root can access them), and
+                                # trying to hash them in non-root Docker images would fail
+                                r'|etc/\.pwd\.lock'
                                 r'|etc/gshadow.*'
                                 r'|etc/mtab'
-                                r'|etc/\.pwd\.lock'
                                 r'|etc/rc(\d|.)\.d/.*'
                                 r'|etc/security/.*'
                                 r'|etc/shadow.*'
-                                r'|gramine/python/.*'
+                                # below file will be removed in final GSC Docker image, so skip it
                                 r'|gramine/app_files/finalize_manifest\.py'
+                                r'|media/.*'
+                                r'|mnt/.*'
                                 r'|proc/.*'
+                                r'|run/.*'
                                 r'|sys/.*'
+                                r'|tmp/.*'
                                 r'|var/.*)$')
     exclude_re = re.compile(excluded_paths_regex)
 

--- a/test/ubuntu18.04-hello-world.dockerfile
+++ b/test/ubuntu18.04-hello-world.dockerfile
@@ -1,5 +1,7 @@
 From ubuntu:18.04
 
-RUN apt-get update
+RUN apt-get -y update
+RUN groupadd -r user && useradd -r -g user user
+USER user
 
 CMD ["echo", "\"Hello World! Let's check escaped symbols: < & > \""]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The updated list of excluded "trusted files" paths better follows the Filesystem Hierarchy Standard (FHS).

Based on:
- https://manpages.debian.org/testing/manpages/hier.7.en.html
- https://manpages.debian.org/testing/systemd/file-hierarchy.7.en.html
- https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html

Fixes #128.

Additionally, this PR includes a quick second commit, which sets `USER` in `ubuntu18.04-hello-world` test. This is for quick tests of non-root images.

## How to test this PR? <!-- (if applicable) -->

Test some Docker images, no functional changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/130)
<!-- Reviewable:end -->
