### PR TITLE
[Docs] Support `debugoptimized` build type

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -89,8 +89,11 @@ Gramine image.
 
 .. option:: -d
 
-   Compile Gramine with debug flags and debug output. If configured to use a
-   prebuilt Gramine image, the image has to support this option.
+   Compile Gramine with ``release``, ``debug`` and ``debugoptimized`` built types.
+   Gramine compiles in ``release`` when ``-d`` flag is not specified. Specify
+   ``-d`` for ``debug`` and ``-d debugoptimized`` for ``debugoptimized``.
+   If configured to use a prebuilt Gramine image, the image has to support these
+   options.
 
 .. option:: -L
 
@@ -170,8 +173,11 @@ parameter `Gramine.Image`.
 
 .. option:: -d
 
-   Compile Gramine with debug flags and debug output. Allows :command:`gsc
-   build` commands to include debug runtime using :option:`-d <gsc-build -d>`.
+   Compile Gramine with ``release``, ``debug`` and ``debugoptimized`` built types.
+   Gramine compiles in ``release`` when ``-d`` flag is not specified. Specify
+   ``-d`` for ``debug`` and ``-d debugoptimized`` for ``debugoptimized``.
+   Allows :command:`gsc build` commands to include debug runtime using
+   :option:`-d <gsc-build -d>`.
 
 .. option:: -L
 

--- a/gsc.py
+++ b/gsc.py
@@ -456,8 +456,9 @@ subcommands.required = True
 
 sub_build = subcommands.add_parser('build', help='Build graminized Docker image')
 sub_build.set_defaults(command=gsc_build)
-sub_build.add_argument('-d', '--debug', action='store_true',
-    help='Compile Gramine with debug flags and output.')
+sub_build.add_argument('-d', '--build_type', nargs='?', const='debug', default='release',
+    choices=['release', 'debug', 'debugoptimized'],
+    help='Compile Gramine with release, debug and debugoptimized built types.')
 sub_build.add_argument('-L', '--linux', action='store_true',
     help='Compile Gramine with Linux PAL in addition to Linux-SGX PAL.')
 sub_build.add_argument('--insecure-args', action='store_true',
@@ -477,8 +478,9 @@ sub_build.add_argument('manifest', help='Manifest file to use.')
 sub_build_gramine = subcommands.add_parser('build-gramine',
     help='Build base-Gramine Docker image')
 sub_build_gramine.set_defaults(command=gsc_build_gramine)
-sub_build_gramine.add_argument('-d', '--debug', action='store_true',
-    help='Compile Gramine with debug flags and output.')
+sub_build_gramine.add_argument('-d', '--build_type', nargs='?', const='debug', default='release',
+    choices=['release', 'debug', 'debugoptimized'],
+    help='Compile Gramine with release, debug and debugoptimized built types.')
 sub_build_gramine.add_argument('-L', '--linux', action='store_true',
     help='Compile Gramine with Linux PAL in addition to Linux-SGX PAL.')
 sub_build_gramine.add_argument('-nc', '--no-cache', action='store_true',

--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -28,7 +28,7 @@ RUN mkdir -p /gramine/driver/asm \
 
 RUN cd /gramine \
     && meson setup build/ --prefix="/gramine/meson_build_output" \
-       --buildtype={% if debug %}debug{% else %}release{% endif %} \
+       --buildtype={{build_type}} \
        -Ddirect=enabled -Dsgx=enabled \
        {% if Distro.startswith('ubuntu') %}-Ddcap=enabled{% endif %} \
        {% if "linux-sgx-driver" in SGXDriver.Repository %} \


### PR DESCRIPTION
GSC doesn't support compiling gramine with `debugoptimized` build type. This PR add support for that.

Usage for different build type:
release: no need to specify `-d` or `-d release`
debug: `-d` or `-d debug`
debugoptimized: `-d debugoptimized`

## How to test this PR? <!-- (if applicable) -->
build hello world example using all three build options as below:

```
release: ./gsc build
debug ./gsc build -d
debugoptimized: ./gsc build -d debugoptimized

```