### PR TITLE
Bump Gramine version in GSC

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -318,7 +318,7 @@ in :file:`config.yaml.template`.
 
 .. describe:: Gramine.Branch
 
-   Use this release/branch of the repository. Default value: ``v1.3.1``.
+   Use this release/branch of the repository. Default value: ``v1.4``.
 
 .. describe:: Gramine.Image
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -19,7 +19,7 @@ Registry: ""
 # branch is guaranteed to work with current Gramine `master` branch).
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "master"
+    Branch:     "v1.4"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -19,7 +19,7 @@ Registry: ""
 # branch is guaranteed to work with current Gramine `master` branch).
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "v1.4"
+    Branch:     "master"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Same as these commits for previous `v1.3.1`:
- 065ad463d6e2ca02487573e900e83c89c8eb6b05
- eff9390bdfb57b1cb1f14ce28b22a65947768a19

**TODO**:
- [ ] After this PR is merged, I'll add a lightweight Git tag `v1.4` to this repo (on the first commit out of these two).

## How to test this PR? <!-- (if applicable) -->

Test manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/132)
<!-- Reviewable:end -->
