### PR TITLE
Remove redundant `sgx.nonpie_binary` manifest option

### DIFF
--- a/templates/entrypoint.common.manifest.template
+++ b/templates/entrypoint.common.manifest.template
@@ -12,7 +12,6 @@ fs.root.uri = "file:/"
 # Gramine's default working dir is '/', so change the working directory to the desired one
 fs.start_dir = "{{working_dir}}"
 
-sgx.nonpie_binary = true
 sgx.debug = {% if debug %} true {% else %} false {% endif %}
 
 {% if insecure_args %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a PR corresponding to "Remove redundant `sgx.nonpie_binary` manifest option" commit in core Gramine. See https://github.com/gramineproject/gramine/pull/1187.

## How to test this PR? <!-- (if applicable) -->

Manually, no functional change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/133)
<!-- Reviewable:end -->
