### PR TITLE
Add LD_LIBRARY_PATH to debian entrypoint manifest

### DIFF
--- a/templates/debian/entrypoint.manifest.template
+++ b/templates/debian/entrypoint.manifest.template
@@ -2,4 +2,8 @@
 
 {% block loader %}
 loader.entrypoint = "file:/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/libsysdb.so"
+
+# Add "/usr/lib/x86_64-linux-gnu" explicitly because ldconfig in Ubuntu 21.04 doesn't
+# produce it; note that this Debian template is used by Ubuntu templates as well
+loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu:{{"{{library_paths}}"}}"
 {% endblock %}

--- a/templates/ubuntu/entrypoint.manifest.template
+++ b/templates/ubuntu/entrypoint.manifest.template
@@ -1,8 +1,1 @@
-{% extends "entrypoint.common.manifest.template" %}
-
-{% block loader %}
-loader.entrypoint = "file:/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/libsysdb.so"
-
-# ldconfig in Ubuntu 21.04 doesn't produce "/usr/lib/x86_64-linux-gnu" so add it explicitly
-loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu:{{"{{library_paths}}"}}"
-{% endblock %}
+{% extends "debian/entrypoint.manifest.template" %}


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

This PR add Missing `LD_LIBRARY_PATH` in debian entrypoint manifest.

Fixes #135 


## How to test this PR? <!-- (if applicable) -->

Create GSC image using curation framework for MySQL with PR https://github.com/gramineproject/contrib/pull/40 and shoule be able to run it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/136)
<!-- Reviewable:end -->
