### PR TITLE
Add a note on bloated auto-generated manifest file

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -26,6 +26,16 @@ command. When the graminized image should run within an Intel SGX enclave, the
 image has to be signed via a :command:`gsc sign-image` command. Subsequently,
 the image can be run using :command:`docker run`.
 
+**NOTE**: As part of the :command:`gsc build` step, GSC generates the manifest
+file with a list of trusted files (files with integrity protection). This list
+contains hashes of *all* files present in the original Docker image. Therefore,
+GSC's manifest creation capability depends on packaging of the original Docker
+image: if the original Docker image is bloated (contains unnecessary files),
+then the generated manifest will also be bloated. Though this doesn't worsen
+security guarantees of Gramine/GSC, it may affect startup performance. Please
+exercise care in pulling in only the dependencies truly required for your Docker
+image.
+
 Prerequisites
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,16 @@ via the ``gsc build`` command. When the graminized image should run within an
 Intel SGX enclave, the image has to be signed via a ``gsc sign-image`` command.
 Subsequently, the image can be run using ``docker run``.
 
+**NOTE**: As part of the ``gsc build`` step, GSC generates the manifest file
+with a list of trusted files (files with integrity protection). This list
+contains hashes of *all* files present in the original Docker image. Therefore,
+GSC's manifest creation capability depends on packaging of the original Docker
+image: if the original Docker image is bloated (contains unnecessary files),
+then the generated manifest will also be bloated. Though this doesn't worsen
+security guarantees of Gramine/GSC, it may affect startup performance. Please
+exercise care in pulling in only the dependencies truly required for your Docker
+image.
+
 Gramine and GSC documentation
 =============================
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As discussed in the Gramine meeting (see https://github.com/gramineproject/gramine/discussions/1232), there is a concern that users may not know about the "bloated" problem of the original Docker image, assuming that GSC is so smart as to generate the minimal required manifest file for Gramine.

This is not true, GSC is pretty dumb in this regard, so a bloated and suboptimal original Docker image will result in a bloated and suboptimal manifest file (and thus e.g. performance problems when using the final GSC-generated Docker image).

This PR adds a note about this.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/137)
<!-- Reviewable:end -->
