### PR TITLE
GSC image size optimizations

### DIFF
--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -5,6 +5,9 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
     sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
 
+# Combine all installation and removal steps in a single RUN command to reduce the final image size.
+# This is because each Dockerfile command creates a new layer which necessarily adds size to the
+# final image. This trick allows to decrease the image size by hundreds of MBs.
 RUN dnf update -y \
     &&  dnf install -y \
         binutils \
@@ -17,13 +20,13 @@ RUN dnf update -y \
         python3-pip \
         python3-protobuf \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
-                                          'tomli>=1.1.0' 'tomli-w>=0.4.0'
-
+                                          'tomli>=1.1.0' 'tomli-w>=0.4.0' \
+    && dnf repolist \
 # For compatibility with Gramine v1.3 or lower
-RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
-
+    && /usr/bin/python3 -B -m pip install 'toml>=0.10' \
 # Install pyelftools after the installation of epel-release as it is provided by the EPEL repo
-RUN dnf install -y python3-pyelftools
+    && dnf install -y python3-pyelftools \
+    && dnf -y clean all
 
 {% if buildtype != "release" %}
 RUN dnf install -y \

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -1,6 +1,9 @@
 {% extends "Dockerfile.common.build.template" %}
 
 {% block install %}
+# Combine all installation and removal steps in a single RUN command to reduce the final image size.
+# This is because each Dockerfile command creates a new layer which necessarily adds size to the
+# final image. This trick allows to decrease the image size by hundreds of MBs.
 RUN apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         binutils \
@@ -8,7 +11,6 @@ RUN apt-get update \
         libcurl4-openssl-dev \
         libprotobuf-c-dev \
         locales \
-        locales-all \
         openssl \
         python3 \
         python3-cryptography \
@@ -16,13 +18,17 @@ RUN apt-get update \
         python3-protobuf \
         python3-pyelftools \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
-                                          'tomli>=1.1.0' 'tomli-w>=0.4.0'
-
+                                          'tomli>=1.1.0' 'tomli-w>=0.4.0' \
 # For compatibility with Gramine v1.3 or lower
-RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
+    && /usr/bin/python3 -B -m pip install 'toml>=0.10' \
+# Since all needed pip packages are installed, we can uninstall python3-pip safely
+    && apt-get remove -y python3-pip \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 {% if buildtype != "release" %}
-RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gdb \
         less \
         libunwind8 \


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
Changes for the GSC image size optimization. Removed package manager caches and packages which is needed in the intermediate layer. 
Debian GSC image size before and after this PR
gsc-ubuntu_20.04_1                      latest    6fd76caa14e6   6 seconds ago        721MB
gsc-ubuntu_20.04_1                      latest    15815de4c481   3 hours ago           184MB
CentOS Image before and after this PR.
gsc-centos_8_1                  latest           a7e864abfd9d   29 seconds ago      682MB
gsc-centos_8_1                 latest           881329d83db1   3 hours ago            559MB

Fixes #140 
  

## How to test this PR? <!-- (if applicable) -->

Create a GSC image debian:11 and observe the size.
Pick the PR and create the GSC image and observe the image size.
GSC image should run without any issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/141)
<!-- Reviewable:end -->
