### PR TITLE
Remove Gramine dependencies that are not needed at runtime

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -169,6 +169,16 @@ of the signing key in them.
 
    Provide passphrase for the enclave signing key (if applicable)
 
+.. option:: -D, --define
+
+   Set image sign-time variables during :command:`gsc sign`.
+
+.. option:: --remove-gramine-deps
+
+   Remove Gramine dependencies that are not needed at runtime. This may have
+   a negative side effect of removing even those dependencies that are actually
+   needed by the original application. Use with care!
+
 .. option:: IMAGE-NAME
 
    Name of the application Docker image

--- a/templates/Dockerfile.common.sign.template
+++ b/templates/Dockerfile.common.sign.template
@@ -17,3 +17,13 @@ FROM {{image}}
 
 COPY --from=unsigned_image /gramine/app_files/*.sig /gramine/app_files/
 COPY --from=unsigned_image /gramine/app_files/*.sgx /gramine/app_files/
+
+{% if args.remove_gramine_deps is trueish %}
+# Temporarily switch to the root user to uninstall packages
+USER root
+
+{% block uninstall %}{% endblock %}
+
+# Switch back to original app_image user
+USER {{app_user}}
+{% endif %}

--- a/templates/centos/Dockerfile.sign.template
+++ b/templates/centos/Dockerfile.sign.template
@@ -1,3 +1,19 @@
 {% extends "Dockerfile.common.sign.template" %}
 
+{% block uninstall %}
+RUN \
+       pip3 uninstall -y click jinja2 \
+          tomli tomli-w \
+          toml \
+       && dnf remove -y binutils \
+          epel-release \
+          expect \
+          openssl \
+          python3-protobuf \
+          python3-pyelftools \
+          python3-cryptography \
+          tcl \
+       && dnf -y clean all;
+{% endblock %}
+
 {% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib64 -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/debian/Dockerfile.sign.template
+++ b/templates/debian/Dockerfile.sign.template
@@ -1,3 +1,22 @@
 {% extends "Dockerfile.common.sign.template" %}
 
+{% block uninstall %}
+RUN \
+       apt-get update -y \
+       && apt-get install -y python3-pip \
+       && pip3 uninstall -y click jinja2 \
+          tomli tomli-w \
+          toml \
+       && apt-get remove -y binutils \
+          expect \
+          libcurl4-openssl-dev \
+          openssl \
+          python3-pip \
+          python3-protobuf \
+          python3-cryptography \
+          python3-pyelftools \
+       && apt-get autoremove -y \
+       && rm -rf /var/lib/apt/lists/*;
+{% endblock %}
+
 {% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib -type d -path '*/site-packages')" &&{% endblock %}


### PR DESCRIPTION

Remove Gramine packages that are not needed at runtime. These packages are needed in build time and not needed in run time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/144)
<!-- Reviewable:end -->
