### PR TITLE
Remove `loader.pal_internal_mem_size` from manifests

### DIFF
--- a/Examples/openvino/ubuntu20.04-openvino.manifest
+++ b/Examples/openvino/ubuntu20.04-openvino.manifest
@@ -1,6 +1,5 @@
 libos.check_invalid_pointers = false
 loader.env.KMP_AFFINITY = "granularity=fine,noverbose,compact,1,0"
-loader.pal_internal_mem_size = "128M"
 sgx.enclave_size = "32G"
 sgx.preheat_enclave = true
 sgx.max_threads = 196

--- a/test/generic.manifest
+++ b/test/generic.manifest
@@ -1,6 +1,3 @@
-# Some workloads like Python may generate huge manifest files
-loader.pal_internal_mem_size = "128M"
-
 sgx.enclave_size = "4G"
 sgx.max_threads = 8
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This manifest option was removed in [Gramine v1.4](https://github.com/gramineproject/gramine/releases/tag/v1.4).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/146)
<!-- Reviewable:end -->
