### PR TITLE
Add Debian12, Ubuntu22.04 and remove Ubuntu18.04 support

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -342,8 +342,8 @@ in :file:`config.yaml.template`.
    Defines Linux distribution to be used to build Gramine in. This distro should
    match the distro underlying the application's Docker image; otherwise the
    results may be unpredictable. Currently supported distros are Ubuntu 20.04,
-   Ubuntu 21.04, Debian 10, Debian 11 and CentOS 8. Default value is
-   ``ubuntu:20.04``.
+   Ubuntu 21.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, Debian 12 and
+   CentOS 8. Default value is ``ubuntu:20.04``.
 
 .. describe:: Registry
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -3,8 +3,8 @@
 # application's Docker image; otherwise the results may be unpredictable.
 #
 # Currently supported distros are:
-# - ubuntu:20.04, ubuntu:21.04
-# - debian:10, debian:11
+# - ubuntu:20.04, ubuntu:21.04, ubuntu:22.04, ubuntu:23.04
+# - debian:10, debian:11, debian:12
 # - centos:8
 Distro: "ubuntu:20.04"
 

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -1,6 +1,7 @@
 {% extends "Dockerfile.common.build.template" %}
 
 {% block install %}
+{% set distro = Distro.split(':') %}
 # Combine all installation and removal steps in a single RUN command to reduce the final image size.
 # This is because each Dockerfile command creates a new layer which necessarily adds size to the
 # final image. This trick allows to decrease the image size by hundreds of MBs.
@@ -13,13 +14,23 @@ RUN apt-get update \
         openssl \
         python3 \
         python3-cryptography \
-        python3-pip \
         python3-protobuf \
         python3-pyelftools \
-    && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
-                                          'tomli>=1.1.0' 'tomli-w>=0.4.0' \
+# Debian 12 and Ubuntu 23.04 adopted PEP 668, which dictates that `pip` can no longer install
+# packages managed by the distro's general-purpose package manager, hence we use `apt-get`
+        {%- if (distro[0] == "debian" and distro[1] | int >= 12) or
+               (distro[0] == "ubuntu" and distro[1] | int >= 23) %}
+           python3-click \
+           python3-jinja2 \
+           python3-tomli \
+           python3-tomli-w \
+        {%- else %}
+           python3-pip \
+           && /usr/bin/python3 -B -m pip install click jinja2 \
+                              'tomli>=1.1.0' 'tomli-w>=0.4.0' \
 # Since all needed pip packages are installed, we can uninstall python3-pip safely
-    && apt-get remove -y python3-pip \
+           && apt-get remove -y python3-pip \
+        {%- endif %}
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -2,6 +2,7 @@
 
 # NOTE: meson v1.2.* has a bug that leads to Gramine build failure because of not found `libcurl.a`
 {% block install %}
+{% set distro = Distro.split(':') %}
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         autoconf \
@@ -20,10 +21,18 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         protobuf-compiler \
         python3 \
         python3-cryptography \
-        python3-pip \
         python3-protobuf \
         wget \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+# please see the comment in Dockerfile.build.template for explanation why this condition is needed
+        {%- if (distro[0] == "debian" and distro[1] | int >= 12) or
+               (distro[0] == "ubuntu" and distro[1] | int >= 23) %}
+           meson \
+           python3-tomli \
+           python3-tomli-w
+        {%- else %}
+           python3-pip \
+           && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+        {%- endif %}
 
 COPY intel-sgx-deb.key /
 

--- a/templates/debian/Dockerfile.sign.template
+++ b/templates/debian/Dockerfile.sign.template
@@ -1,20 +1,29 @@
 {% extends "Dockerfile.common.sign.template" %}
 
 {% block uninstall %}
+{% set distro = Distro.split(':') %}
 RUN \
-       apt-get update -y \
-       && apt-get install -y python3-pip \
-       && pip3 uninstall -y click jinja2 \
-          tomli tomli-w \
-       && apt-get remove -y binutils \
-          expect \
-          openssl \
-          python3-pip \
-          python3-protobuf \
-          python3-cryptography \
-          python3-pyelftools \
-       && apt-get autoremove -y \
-       && rm -rf /var/lib/apt/lists/*;
+        apt-get remove -y binutils \
+        expect \
+        openssl \
+        python3-protobuf \
+        python3-cryptography \
+        python3-pyelftools \
+# please see the comment in Dockerfile.build.template for explanation why this condition is needed
+        {%- if (distro[0] == "debian" and distro[1] | int >= 12) or
+               (distro[0] == "ubuntu" and distro[1] | int >= 23) %}
+           python3-tomli \
+           python3-tomli-w \
+           python3-click \
+           python3-jinja2 \
+        {%- else %}
+           && apt-get update -y \
+           && apt-get install -y python3-pip \
+           && pip3 uninstall -y click jinja2 tomli tomli-w \
+           && apt-get remove -y python3-pip \
+        {%- endif %}
+        && apt-get autoremove -y \
+        && rm -rf /var/lib/apt/lists/*;
 {% endblock %}
 
 {% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib -type d -path '*/site-packages')" &&{% endblock %}


### PR DESCRIPTION

This PR fixes the build issues seen with newer distros ubuntu22.04, debian12 etc.  For newer distros the `apt-get install` is used to install the python packages. 
Also removes the support for ubuntu18.04.

This PR fixes #153

Take the hello-world example in the test folder and modify it to use the ubuntu22.04 base image.
Edit the `config.yaml` file to select the distro as ubuntu:22.04
Do the `gsc build` and `gsc sign` commands.
Expected result: The build build should pass with out errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/155)
<!-- Reviewable:end -->
