### PR TITLE
Remove `toml` support

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -53,7 +53,6 @@ pip. GSC requires Python 3.6 or later.
 
    sudo apt-get install docker.io python3 python3-pip
    pip3 install docker jinja2 tomli tomli-w pyyaml
-   pip3 install toml  # for compatibility with Gramine v1.3 or lower
 
 SGX software stack
 ------------------

--- a/finalize_manifest.py
+++ b/finalize_manifest.py
@@ -86,16 +86,6 @@ def generate_trusted_files(root_dir, already_added_files):
             if '\n' in filename:
                 # we use TOML's basic single-line strings, can't have newlines
                 continue
-            if '\\x' in filename:
-                # Python TOML parser has a bug that prevents it from correctly handling `\x`
-                # sequences in strings (see https://github.com/uiri/toml/issues/404). Fortunately,
-                # the only files that exhibit such pattern are systemd helper files which graminized
-                # apps will never access anyway.
-                # FIXME: Now we switched to `tomli`, but GSC can still use Gramine v1.3 or lower
-                #        which uses `toml`. When GSC removes support for v1.3, can remove this.
-                print(f'\t[from inside Docker container] File {filename} contains `\\x` sequence '
-                       'and will be skipped from `sgx.trusted_files`!')
-                continue
 
             if not os.access(filename, os.R_OK):
                 # only accessible files are added as trusted files (note that this check is below

--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -11,7 +11,7 @@ FROM {{app_image}}
 # Temporarily switch to the root user to install packages
 USER root
 
-# Install distro-specific packages to run Gramine (e.g., python3, protobuf, toml, etc.)
+# Install distro-specific packages to run Gramine (e.g., python3, protobuf, tomli, etc.)
 {% block install %}{% endblock %}
 
 # Create a directory that will store apploader.sh and entrypoint files.

--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -4,7 +4,7 @@ FROM {{Registry}}/{{Distro}} AS gramine
 FROM {{Distro}} AS gramine
 {% endif %}
 
-# Install distro-specific packages to build Gramine (e.g., python3, protobuf, toml, etc.)
+# Install distro-specific packages to build Gramine (e.g., python3, protobuf, tomli, etc.)
 {% block install %}{% endblock %}
 
 RUN git clone {{Gramine.Repository}} /gramine

--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -22,8 +22,6 @@ RUN dnf update -y \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
                                           'tomli>=1.1.0' 'tomli-w>=0.4.0' \
     && dnf repolist \
-# For compatibility with Gramine v1.3 or lower
-    && /usr/bin/python3 -B -m pip install 'toml>=0.10' \
 # Install pyelftools after the installation of epel-release as it is provided by the EPEL repo
     && dnf install -y python3-pyelftools \
     && dnf -y clean all

--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -37,7 +37,4 @@ RUN dnf update -y \
         wget \
     && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56'
 
-# For compatibility with Gramine v1.3 or lower
-RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
-
 {% endblock %}

--- a/templates/centos/Dockerfile.sign.template
+++ b/templates/centos/Dockerfile.sign.template
@@ -4,7 +4,6 @@
 RUN \
        pip3 uninstall -y click jinja2 \
           tomli tomli-w \
-          toml \
        && dnf remove -y binutils \
           epel-release \
           expect \

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -18,8 +18,6 @@ RUN apt-get update \
         python3-pyelftools \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
                                           'tomli>=1.1.0' 'tomli-w>=0.4.0' \
-# For compatibility with Gramine v1.3 or lower
-    && /usr/bin/python3 -B -m pip install 'toml>=0.10' \
 # Since all needed pip packages are installed, we can uninstall python3-pip safely
     && apt-get remove -y python3-pip \
     && apt-get autoremove -y \

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -24,9 +24,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         wget \
     && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56'
 
-# For compatibility with Gramine v1.3 or lower
-RUN /usr/bin/python3 -B -m pip install 'toml>=0.10'
-
 COPY intel-sgx-deb.key /
 
 RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' \

--- a/templates/debian/Dockerfile.sign.template
+++ b/templates/debian/Dockerfile.sign.template
@@ -6,7 +6,6 @@ RUN \
        && apt-get install -y python3-pip \
        && pip3 uninstall -y click jinja2 \
           tomli tomli-w \
-          toml \
        && apt-get remove -y binutils \
           expect \
           openssl \

--- a/test/generic.manifest
+++ b/test/generic.manifest
@@ -1,9 +1,6 @@
 sgx.enclave_size = "4G"
 sgx.max_threads = 8
 
-# FIXME: `toml` Python lib that was used in Gramine v1.3 and lower hangs/fails on non-homogeneous
-#        TOML arrays, so until we fully deprecate support for Gramine v1.3 in GSC, specify items in
-#        the sgx.trusted_files array only as strings (never as dicts `{ "uri": "file:file1" }`)
 sgx.trusted_files = [
   "file:/gramine/app_files/entrypoint.manifest",  # unused entry, only to test merging of manifests
 ]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `toml` Python package was used in Gramine v1.3. Now that Gramine is of v1.5, it's time to remove support for `toml`.

## How to test this PR? <!-- (if applicable) -->

Manually some GSC workloads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/157)
<!-- Reviewable:end -->
