### PR TITLE
Fix incorrect parsing of `SIGSTRUCT.DATE`

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -404,7 +404,7 @@ def gsc_sign_image(args):
           f'`{unsigned_image_name}`.')
 
 
-# Simplified version of read_sigstruct from python/graminelibos/sgx_get_token.py
+# Simplified version of `Sigstruct.from_bytes()` from python/graminelibos/sigstruct.py
 def read_sigstruct(sig):
     # Offsets for fields in SIGSTRUCT (defined by the SGX HW architecture, they never change)
     SGX_ARCH_ENCLAVE_CSS_DATE = 20
@@ -416,19 +416,27 @@ def read_sigstruct(sig):
     SGX_ARCH_ENCLAVE_CSS_MISC_SELECT = 900
     # Field format: (offset, type, value)
     fields = {
-        'date': (SGX_ARCH_ENCLAVE_CSS_DATE, '<HBB', 'year', 'month', 'day'),
-        'modulus': (SGX_ARCH_ENCLAVE_CSS_MODULUS, '384s', 'modulus'),
-        'enclave_hash': (SGX_ARCH_ENCLAVE_CSS_ENCLAVE_HASH, '32s', 'enclave_hash'),
-        'isv_prod_id': (SGX_ARCH_ENCLAVE_CSS_ISV_PROD_ID, '<H', 'isv_prod_id'),
-        'isv_svn': (SGX_ARCH_ENCLAVE_CSS_ISV_SVN, '<H', 'isv_svn'),
-        'attributes': (SGX_ARCH_ENCLAVE_CSS_ATTRIBUTES, '8s8s', 'flags', 'xfrms'),
-        'misc_select': (SGX_ARCH_ENCLAVE_CSS_MISC_SELECT, '4s', 'misc_select'),
+        'date_year': (SGX_ARCH_ENCLAVE_CSS_DATE + 2, '<H'),
+        'date_month': (SGX_ARCH_ENCLAVE_CSS_DATE + 1, '<B'),
+        'date_day': (SGX_ARCH_ENCLAVE_CSS_DATE, '<B'),
+        'modulus': (SGX_ARCH_ENCLAVE_CSS_MODULUS, '384s'),
+        'enclave_hash': (SGX_ARCH_ENCLAVE_CSS_ENCLAVE_HASH, '32s'),
+        'isv_prod_id': (SGX_ARCH_ENCLAVE_CSS_ISV_PROD_ID, '<H'),
+        'isv_svn': (SGX_ARCH_ENCLAVE_CSS_ISV_SVN, '<H'),
+        'flags': (SGX_ARCH_ENCLAVE_CSS_ATTRIBUTES, '8s'),
+        'xfrms': (SGX_ARCH_ENCLAVE_CSS_ATTRIBUTES + 8, '8s'),
+        'misc_select': (SGX_ARCH_ENCLAVE_CSS_MISC_SELECT, '4s'),
     }
     attr = {}
-    for field in fields.values():
-        values = struct.unpack_from(field[1], sig, field[0])
-        for i, value in enumerate(values):
-            attr[field[i + 2]] = value
+    for key, (offset, fmt) in fields.items():
+        if key in ['date_year', 'date_month', 'date_day']:
+            try:
+                attr[key] = int(f'{struct.unpack_from(fmt, sig, offset)[0]:x}')
+            except ValueError:
+                print(f'Misencoded {key} in SIGSTRUCT!', file=sys.stderr)
+                raise
+            continue
+        attr[key] = struct.unpack_from(fmt, sig, offset)[0]
 
     return attr
 
@@ -462,7 +470,8 @@ def gsc_info_image(args):
             sigstruct['mr_signer'] = mrsigner.digest().hex()
             sigstruct['isv_prod_id'] = attr['isv_prod_id']
             sigstruct['isv_svn'] = attr['isv_svn']
-            sigstruct['date'] = '%d-%02d-%02d' % (attr['year'], attr['month'], attr['day'])
+            sigstruct['date'] = '%d-%02d-%02d' % (
+                attr['date_year'], attr['date_month'], attr['date_day'])
             sigstruct['flags'] = attr['flags'].hex()
             sigstruct['xfrms'] = attr['xfrms'].hex()
             sigstruct['misc_select'] = attr['misc_select'].hex()


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This is a commit corresponding to ["[python] Fix wrong format of `SIGSTRUCT.DATE`"](https://github.com/gramineproject/gramine/pull/1287) commit in core Gramine.

Fixes https://github.com/gramineproject/gsc/issues/159.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/160)
<!-- Reviewable:end -->
