### PR TITLE
Pin to meson versions >=0.56,<1.2.0

### DIFF
--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -5,6 +5,7 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-* &&\
     sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
 
+# NOTE: meson v1.2.0 has a bug that leads to Gramine build failure because of not found `libcurl.a`
 RUN dnf update -y \
     &&  dnf install -y \
         autoconf \
@@ -35,6 +36,6 @@ RUN dnf update -y \
         python3-protobuf \
         rpm-build \
         wget \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,<1.2.0'
 
 {% endblock %}

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -1,5 +1,6 @@
 {% extends "Dockerfile.common.compile.template" %}
 
+# NOTE: meson v1.2.0 has a bug that leads to Gramine build failure because of not found `libcurl.a`
 {% block install %}
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -22,7 +23,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         python3-pip \
         python3-protobuf \
         wget \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,<1.2.0'
 
 COPY intel-sgx-deb.key /
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Meson v1.2.0 has a bug that prevents Gramine from building. Because the meson bug is non-trivial, this commit works around this by pinning meson to known good versions.

Fixes #163.

## How to test this PR? <!-- (if applicable) -->

Any GSC workload (it fails on any Debian/Ubuntu workload without this PR).