### PR TITLE
Bump Gramine version in GSC to v1.5

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -359,7 +359,7 @@ in :file:`config.yaml.template`.
 
 .. describe:: Gramine.Branch
 
-   Use this release/branch of the repository. Default value: ``v1.4``.
+   Use this release/branch of the repository. Default value: ``v1.5``.
 
 .. describe:: Gramine.Image
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -23,7 +23,7 @@ Registry: ""
 # branch is guaranteed to work with current Gramine `master` branch).
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "v1.5"
+    Branch:     "master"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -23,7 +23,7 @@ Registry: ""
 # branch is guaranteed to work with current Gramine `master` branch).
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "master"
+    Branch:     "v1.5"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graminized Docker container will run); there are several variants of the SGX driver:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Same as these commits for previous v1.4:

- https://github.com/gramineproject/gsc/commit/b4c30bf351c47898a84f0f6b7e7811c1d16ec36d
- https://github.com/gramineproject/gsc/commit/a60a4991d7351c1b7489444c694638ca9cc68e39

TODO:
- [ ] After this PR is merged, I'll modify the currently-incorrect lightweight Git tag v1.5 to this repo (on the first commit out of these two).

## How to test this PR? <!-- (if applicable) -->

Test manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/165)
<!-- Reviewable:end -->
