### PR TITLE
Remove `loader.argv0_override` from manifest template

### DIFF
--- a/templates/entrypoint.common.manifest.template
+++ b/templates/entrypoint.common.manifest.template
@@ -18,7 +18,6 @@ sgx.debug = {% if buildtype != "release" %} true {% else %} false {% endif %}
 # !! INSECURE !! Allow passing command-line arguments from the host without validation.
 # Most Docker images rely on runtime arguments and hence, a more general technique is required.
 # The issue is documented at https://github.com/gramineproject/gsc/issues/13.
-loader.argv0_override = "/gramine/app_files/{{binary_basename}}"
 loader.insecure__use_cmdline_argv = true
 {% else %}
 loader.argv_src_file = "file:/gramine/app_files/trusted_argv"


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This manifest option was removed in Gramine v1.3.

Fixes https://github.com/gramineproject/gsc/issues/83.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Basic GSC Python image test (by checking the option is removed exactly and the image works fine).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/167)
<!-- Reviewable:end -->
