### PR TITLE
Add ubi8, ubi8-minimal support

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -311,8 +311,14 @@ in :file:`config.yaml.template`.
    Defines Linux distribution to be used to build Gramine in. This distro should
    match the distro underlying the application's Docker image; otherwise the
    results may be unpredictable. Currently supported distros are Ubuntu 20.04,
-   Ubuntu 21.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, Debian 12 and
-   CentOS 8. Default value is ``ubuntu:20.04``.
+   Ubuntu 21.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, Debian 12,
+   CentOS 8, Red Hat Universal Base Image (UBI) 8 and Red Hat Universal Base
+   Image (UBI) 8 minimal. Default value is ``ubuntu:20.04``.
+
+   .. warning::
+      Please register and subscribe your host RHEL system to the Red Hat
+      Customer Portal to use Red Hat Universal Base Image (UBI) 8 and
+      UBI8-minimal distros.
 
 .. describe:: Registry
 
@@ -492,9 +498,10 @@ Operating System dependency
 
 GSC relies on Gramine to execute Linux applications inside Intel SGX enclaves and
 the installation of prerequisites depends on package manager and package
-repositories. Docker images based on Ubuntu and CentOS are supported by GSC.
-GSC can simply be extended to support other distributions by
-providing a set of templates for this distribution in :file:`templates/`.
+repositories. Docker images based on Ubuntu, CentOS and Red Hat Universal Base
+Image are supported by GSC. GSC can simply be extended to support other
+distributions by providing a set of templates for this distribution in
+:file:`templates/`.
 
 Trusted data in Docker volumes
 ------------------------------

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -6,6 +6,8 @@
 # - ubuntu:20.04, ubuntu:21.04, ubuntu:22.04, ubuntu:23.04
 # - debian:10, debian:11, debian:12
 # - centos:8
+# - redhat/ubi8:8.8
+# - redhat/ubi8-minimal:8.8
 Distro: "ubuntu:20.04"
 
 # If the image has a specific registry, define it here.

--- a/templates/redhat/ubi8-minimal/Dockerfile.build.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.build.template
@@ -1,0 +1,43 @@
+{% extends "Dockerfile.common.build.template" %}
+
+{% block install %}
+COPY redhat.repo /etc/yum.repos.d/
+COPY pki/entitlement/ /etc/pki/entitlement/
+COPY redhat-uep.pem /etc/rhsm/ca/
+
+# Combine all installation and removal steps in a single RUN command to reduce the final image size.
+# This is because each Dockerfile command creates a new layer which necessarily adds size to the
+# final image. This trick allows to decrease the image size by hundreds of MBs.
+RUN rm -rf /etc/rhsm-host \
+    && rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && microdnf update -y \
+    && microdnf install -y subscription-manager \
+    && subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
+    && microdnf install -y \
+        binutils \
+        findutils \
+        openssl \
+        pkgconfig \
+        protobuf-c-devel \
+        python3 \
+        python3-cryptography \
+        python3-pip \
+        python3-protobuf \
+        python3-pyelftools \
+        wget \
+        which \
+    && /usr/bin/python3 -B -m pip install click jinja2 \
+                                          'tomli>=1.1.0' 'tomli-w>=0.4.0' \
+    && microdnf repolist \
+    && microdnf -y clean all \
+    && rm -rf /etc/yum.repos.d/redhat.repo /etc/pki/entitlement/* /etc/rhsm/ca/redhat-uep.pem
+
+{% if buildtype != "release" %}
+RUN microdnf install -y \
+        gdb \
+        less \
+        libunwind \
+        python3-pytest \
+        strace
+{% endif %}
+{% endblock %}

--- a/templates/redhat/ubi8-minimal/Dockerfile.compile.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.compile.template
@@ -1,0 +1,44 @@
+{% extends "Dockerfile.common.compile.template" %}
+
+{% block install %}
+COPY redhat.repo /etc/yum.repos.d/
+COPY pki/entitlement/ /etc/pki/entitlement/
+COPY redhat-uep.pem /etc/rhsm/ca/
+
+# NOTE: meson v1.2.* has a bug that leads to Gramine build failure because of not found `libcurl.a`
+RUN rm -rf /etc/rhsm-host \
+    && rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && microdnf update -y \
+    && microdnf install -y subscription-manager \
+    && subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
+    && microdnf install -y \
+        autoconf \
+        bison \
+        curl \
+        elfutils-libelf-devel \
+        flex \
+        gawk \
+        gcc-c++ \
+        git \
+        httpd \
+        libevent-devel \
+        make \
+        nasm \
+        ncurses-devel \
+        ninja-build \
+        openssl-devel \
+        patch \
+        pkg-config \
+        protobuf-c-compiler \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-cryptography \
+        python3-pip \
+        python3-protobuf \
+        rpm-build \
+        wget \
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+
+{% endblock %}

--- a/templates/redhat/ubi8-minimal/Dockerfile.sign.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.sign.template
@@ -1,0 +1,16 @@
+{% extends "Dockerfile.common.sign.template" %}
+
+{% block uninstall %}
+RUN \
+       pip3 uninstall -y click jinja2 \
+          tomli tomli-w \
+       && microdnf remove -y binutils \
+          epel-release \
+          openssl \
+          python3-cryptography \
+          python3-protobuf \
+          python3-pyelftools \
+       && microdnf -y clean all;
+{% endblock %}
+
+{% block path %}export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib64 -type d -path '*/site-packages')" &&{% endblock %}

--- a/templates/redhat/ubi8-minimal/apploader.template
+++ b/templates/redhat/ubi8-minimal/apploader.template
@@ -1,0 +1,1 @@
+{% extends "centos/apploader.template" %}

--- a/templates/redhat/ubi8-minimal/entrypoint.manifest.template
+++ b/templates/redhat/ubi8-minimal/entrypoint.manifest.template
@@ -1,0 +1,1 @@
+{% extends "centos/entrypoint.manifest.template" %}

--- a/templates/redhat/ubi8/Dockerfile.build.template
+++ b/templates/redhat/ubi8/Dockerfile.build.template
@@ -1,0 +1,40 @@
+{% extends "Dockerfile.common.build.template" %}
+
+{% block install %}
+COPY redhat.repo /etc/yum.repos.d/
+COPY pki/entitlement/ /etc/pki/entitlement/
+COPY redhat-uep.pem /etc/rhsm/ca/
+
+# Combine all installation and removal steps in a single RUN command to reduce the final image size.
+# This is because each Dockerfile command creates a new layer which necessarily adds size to the
+# final image. This trick allows to decrease the image size by hundreds of MBs.
+RUN rm -rf /etc/rhsm-host \
+    && subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
+    && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf update -y \
+    && dnf install -y \
+        binutils \
+        openssl \
+        pkgconfig \
+        protobuf-c-devel \
+        python3 \
+        python3-cryptography \
+        python3-pip \
+        python3-protobuf \
+        python3-pyelftools \
+        wget \
+    && /usr/bin/python3 -B -m pip install click jinja2 \
+                                          'tomli>=1.1.0' 'tomli-w>=0.4.0' \
+    && dnf repolist \
+    && dnf -y clean all \
+    && rm -rf /etc/yum.repos.d/redhat.repo /etc/pki/entitlement/* /etc/rhsm/ca/redhat-uep.pem
+
+{% if buildtype != "release" %}
+RUN dnf install -y \
+        gdb \
+        less \
+        libunwind \
+        python3-pytest \
+        strace
+{% endif %}
+{% endblock %}

--- a/templates/redhat/ubi8/Dockerfile.compile.template
+++ b/templates/redhat/ubi8/Dockerfile.compile.template
@@ -1,0 +1,43 @@
+{% extends "Dockerfile.common.compile.template" %}
+
+{% block install %}
+COPY redhat.repo /etc/yum.repos.d/
+COPY pki/entitlement/ /etc/pki/entitlement/
+COPY redhat-uep.pem /etc/rhsm/ca/
+
+# NOTE: meson v1.2.* has a bug that leads to Gramine build failure because of not found `libcurl.a`
+RUN rm -rf /etc/rhsm-host \
+    && subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
+    && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf update -y \
+    && dnf install -y \
+        autoconf \
+        bison \
+        curl \
+        elfutils-libelf-devel \
+        flex \
+        gawk \
+        gcc-c++ \
+        git \
+        httpd \
+        libevent-devel \
+        make \
+        nasm \
+        ncurses-devel \
+        ninja-build \
+        openssl-devel \
+        patch \
+        pkg-config \
+        protobuf-c-compiler \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-cryptography \
+        python3-pip \
+        python3-protobuf \
+        rpm-build \
+        wget \
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+
+{% endblock %}

--- a/templates/redhat/ubi8/Dockerfile.sign.template
+++ b/templates/redhat/ubi8/Dockerfile.sign.template
@@ -1,0 +1,1 @@
+{% extends "centos/Dockerfile.sign.template" %}

--- a/templates/redhat/ubi8/apploader.template
+++ b/templates/redhat/ubi8/apploader.template
@@ -1,0 +1,1 @@
+{% extends "centos/apploader.template" %}

--- a/templates/redhat/ubi8/entrypoint.manifest.template
+++ b/templates/redhat/ubi8/entrypoint.manifest.template
@@ -1,0 +1,1 @@
+{% extends "centos/entrypoint.manifest.template" %}


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Add `ubi8`, `ubi8-minimal` support.

Implementation note: Due to unavailability of `expect`, `protobuf-c-devel` and `nasm` packages in ubi8 CentOS repository is made available under ubi8 to install these 3 packages.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Take the `hello-world` example in the test folder and modify it to use `redhat/ubi8:8.8` and `redhat/ubi8-minimal:8.8` as base image.
Edit the `config.yaml` file to select the distro as `redhat/ubi8:8.8` and `redhat/ubi8-minimal:8.8`.
Do the `gsc build` and `gsc sign` commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/168)
<!-- Reviewable:end -->
