### PR TITLE
Add `exec` command to `apploader.sh` entrypoint

### DIFF
--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -11,10 +11,10 @@ set -e
 # Default to Linux-SGX if no PAL was specified
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
-    gramine-sgx /gramine/app_files/entrypoint \
+    exec gramine-sgx /gramine/app_files/entrypoint \
         {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
         "${@}"{% endif %}
 else
-    gramine-direct /gramine/app_files/entrypoint \
+    exec gramine-direct /gramine/app_files/entrypoint \
     {{ binary_arguments | map('shlex_quote') | join(' ') }} "${@}"
 fi


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the `apploader.sh` entrypoint bash script spawned Gramine as a child process (i.e. a simple `gramine-sgx app ...`). This resulted in the Gramine process not catching the SIGTERM signal that was e.g. sent via `docker stop`. That's because in a bash script, signals are not delivered to child processes.

This commit fixes this problem by replacing the bash-script process with the Gramine process, instead of spawning a child.

See https://github.com/gramineproject/gramine/discussions/1560 for more discussions.

## How to test this PR? <!-- (if applicable) -->

Test manually on some long-running workload (e.g. OpenVINO) and `docker stop`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/171)
<!-- Reviewable:end -->
