### PR TITLE
Remove obsolete "--debug" and "--linux" options

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -101,21 +101,6 @@ Gramine image.
    Use <buildtype> value ``release``, ``debug`` or ``debugoptimized`` to
    compile Gramine in the corresponding mode. Default: ``release``.
 
-..
-  TODO: Drop `-d` option with GSC v1.6 release
-
-.. option:: -d, --debug
-
-   Compile Gramine with debug flags and debug output.
-
-   .. deprecated:: 1.5
-      Use :option:`--buildtype`.
-
-.. option:: -L
-
-   Compile Gramine with Linux PAL in addition to Linux-SGX PAL. If configured
-   to use a prebuilt Gramine image, the image has to support this option.
-
 .. option:: --insecure-args
 
    Allow untrusted arguments to be specified at :command:`docker run`. Otherwise
@@ -201,22 +186,6 @@ parameter `Gramine.Image`.
 
    Use <buildtype> value ``release``, ``debug`` or ``debugoptimized`` to
    compile Gramine in the corresponding mode. Default: ``release``.
-
-..
-  TODO: Drop `-d` option with GSC v1.6 release
-
-.. option:: -d, --debug
-
-   Compile Gramine with debug flags and debug output.
-
-   .. deprecated:: 1.5
-      Use :option:`--buildtype`.
-
-.. option:: -L
-
-   Compile Gramine with Linux PAL in addition to Linux-SGX PAL. Allows
-   :command:`gsc build` commands to include the Linux PAL using :option:`-L
-   <gsc-build -L>`.
 
 .. option:: --no-cache
 
@@ -416,8 +385,7 @@ executable arguments may be supplied to the :command:`docker run` command.
 Execute with Linux PAL instead of Linux-SGX PAL
 -----------------------------------------------
 
-When specifying :option:`-L <gsc-build -L>`  during GSC :command:`gsc build`,
-you may select the Linux PAL at Docker run time instead of the Linux-SGX PAL by
+You may select the Linux PAL at Docker run time instead of the Linux-SGX PAL by
 specifying the environment variable :envvar:`GSC_PAL` as an option to the
 :command:`docker run` command. When using the Linux PAL, it is not necessary to
 sign the image via a :command:`gsc sign-image` command.

--- a/gsc.py
+++ b/gsc.py
@@ -494,11 +494,6 @@ sub_build.set_defaults(command=gsc_build)
 sub_build.add_argument('-b', '--buildtype', choices=['release', 'debug', 'debugoptimized'],
     default='release', help='Compile Gramine in release, debug or debugoptimized mode.')
 
-# TODO: Drop `-d` option with GSC v1.6 release
-sub_build.add_argument('-d', '--debug', action='store_const', dest='buildtype',
-    const='debug', help='Compile Gramine with debug flags and output (deprecated).')
-sub_build.add_argument('-L', '--linux', action='store_true',
-    help='Compile Gramine with Linux PAL in addition to Linux-SGX PAL.')
 sub_build.add_argument('--insecure-args', action='store_true',
     help='Allow to specify untrusted arguments during Docker run. '
          'Otherwise arguments are ignored.')
@@ -519,11 +514,6 @@ sub_build_gramine.set_defaults(command=gsc_build_gramine)
 sub_build_gramine.add_argument('-b', '--buildtype', choices=['release', 'debug', 'debugoptimized'],
     default='release', help='Compile Gramine in release, debug or debugoptimized mode.')
 
-# TODO: Drop `-d` option with GSC v1.6 release
-sub_build_gramine.add_argument('-d', '--debug', action='store_const', dest='buildtype',
-    const='debug', help='Compile Gramine with debug flags and output (deprecated).')
-sub_build_gramine.add_argument('-L', '--linux', action='store_true',
-    help='Compile Gramine with Linux PAL in addition to Linux-SGX PAL.')
 sub_build_gramine.add_argument('-nc', '--no-cache', action='store_true',
     help='Build graminized Docker image without any cached images.')
 sub_build_gramine.add_argument('--rm', action='store_true',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

After the introduction of `--buildtype` option which supports `release`, `debug` and `debugoptimized` buildtype in GSC v1.5, `--debug` option became obsolote and marked for removal in V1.6- release.

Option `--linux` used to compile Gramine with Linux-PAL. But bydefault we compile Gramine with both Linux-PAL and Linux-SGX [here](https://github.com/gramineproject/gsc/blob/5099b641e171942f87254d751fe4bee086a869c2/templates/Dockerfile.common.compile.template#L32), hence this option doesn't have any use and can be removed.
## How to test this PR? <!-- (if applicable) -->

Graminize any image using GSC and run in LINUX PAL (`gramine-direct`) without using `-L` and using instructions: https://gramine.readthedocs.io/projects/gsc/en/latest/#execute-with-linux-pal-instead-of-linux-sgx-pal

Also we should get error if try to use `-L` and `-d` options

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/174)
<!-- Reviewable:end -->
