### PR TITLE
Delete dangling image generated  while signing

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -14,6 +14,7 @@ import shutil
 import struct
 import sys
 import tempfile
+import uuid
 
 import docker  # pylint: disable=import-error
 import jinja2
@@ -449,13 +450,18 @@ def gsc_sign_image(args):
     tmp_build_key_path = tmp_build_path / 'gsc-signer-key.pem'
     shutil.copyfile(os.path.abspath(args.key), tmp_build_key_path)
 
+    build_id = uuid.uuid4().hex
     try:
         # `forcerm` parameter forces removal of intermediate Docker images even after unsuccessful
         # builds, to not leave the signing key lingering in any Docker containers
         build_docker_image(docker_socket.api, tmp_build_path, signed_image_name, 'Dockerfile.sign',
-                           forcerm=True, buildargs={"passphrase": args.passphrase})
+                           forcerm=True, buildargs={'passphrase': args.passphrase,
+                           'BUILD_ID': build_id})
     finally:
         os.remove(tmp_build_key_path)
+        # Remove a temporary image created during multistage docker build to save disk space.
+        # Please note that removing the image doesn't assure security.
+        docker_socket.api.prune_images(filters={'label': 'build_id=' + build_id})
 
     if get_docker_image(docker_socket, signed_image_name) is None:
         print(f'Failed to build a signed graminized Docker image `{signed_image_name}`.')

--- a/templates/Dockerfile.common.sign.template
+++ b/templates/Dockerfile.common.sign.template
@@ -1,5 +1,11 @@
 # Sign image in a separate stage to ensure that signing key is never part of the final image
 FROM {{image}} as unsigned_image
+
+# BUILD_ID is a random UUID provided by `gsc sign-image` command, to be able to remove
+# the temporary intermediate-stage image later in `gsc sign-image`, to free disk space
+ARG BUILD_ID
+LABEL build_id=$BUILD_ID
+
 COPY gsc-signer-key.pem /gramine/app_files/gsc-signer-key.pem
 
 ARG passphrase


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

GSC signing have multistage build process and that generates a dangling image which consumes disk space, hence this image can be removed to save disk space.

This PR removes the dangling image generated while signing.

## How to test this PR? <!-- (if applicable) -->

Check the docker image list before and after signing. There should not be any new dangling image with <none> tag and repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/175)
<!-- Reviewable:end -->
