### PR TITLE
Automatically detect the distro of the supplied docker image

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -258,8 +258,8 @@ follows three main stages and produces an image named ``gsc-<image-name>``.
 
 #. **Building Gramine.** The first stage builds Gramine from sources based on
    the provided configuration (see :file:`config.yaml`) which includes the
-   distribution (e.g., Ubuntu 20.04), Gramine repository, and the Intel SGX
-   driver details. This stage can be skipped if :command:`gsc build` uses a
+   distribution, Gramine repository, and the Intel SGX driver details.
+   This stage can be skipped if :command:`gsc build` uses a
    pre-built Gramine Docker image.
 
 #. **Graminizing the application image.** The second stage copies the important
@@ -309,10 +309,12 @@ in :file:`config.yaml.template`.
 .. describe:: Distro
 
    Defines Linux distribution to be used to build Gramine in. This distro should
-   match the distro underlying the application's Docker image; otherwise the
-   results may be unpredictable. Currently supported distros are Ubuntu 20.04,
-   Ubuntu 21.04, Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, Debian 12 and
-   CentOS 8. Default value is ``ubuntu:20.04``.
+   match the distro of the supplied Docker image; otherwise the results may be
+   unpredictable. Currently supported distros are Ubuntu 20.04, Ubuntu 21.04,
+   Ubuntu 22.04, Ubuntu 23.04, Debian 10, Debian 11, Debian 12 and CentOS 8.
+   Default value is ``auto`` which means GSC automatically detects the distro
+   of the supplied Docker image. User also have the option to provide one of the
+   supported distros mentioned above.
 
 .. describe:: Registry
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -6,7 +6,10 @@
 # - ubuntu:20.04, ubuntu:21.04, ubuntu:22.04, ubuntu:23.04
 # - debian:10, debian:11, debian:12
 # - centos:8
-Distro: "ubuntu:20.04"
+
+# GSC detects the distro automatically of the supplied image if ditro is set to `auto`.
+# User also have the option to provide one of the supported distros mentioned above.
+Distro: "auto"
 
 # If the image has a specific registry, define it here.
 # Empty by default; example value: "registry.access.redhat.com/ubi8".


### PR DESCRIPTION
## Description of the changes

GSC can automatically detect the distro of the supplied image, hence user don't have to update the distro in `config.yaml` after this PR.

## How to test this PR?

1. No need to make any changes in the `config.yaml` for setting distro, do the GSC build and test.
2. Set supported distro and do GSC build and test
