### PR TITLE
Fix access issue with `intel-sgx-deb.key`

### DIFF
--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -38,7 +38,7 @@ COPY intel-sgx-deb.key /
 
 RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' \
     > /etc/apt/sources.list.d/intel-sgx.list \
-    && apt-key add intel-sgx-deb.key
+    && apt-key add /intel-sgx-deb.key
 
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y libsgx-dcap-quote-verify-dev


### PR DESCRIPTION
## Description of the changes

`intel-sgx-deb.key` is copied at root directory `/` few steps above but accessed using current working directory. It wasn't accessible in an image where current working directory is not a root directory `/`.

## How to test this PR?

Create a distro image which have current working directory other than root directory `/` and specify the same distro image in configuration file and do the GSC build.

