### PR TITLE
[Docs] State explicitly that Linux PAL is `gramine-direct`

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -388,13 +388,14 @@ executable arguments may be supplied to the :command:`docker run` command.
    :command:`gsc build`.
 
 
-Execute with Linux PAL instead of Linux-SGX PAL
------------------------------------------------
+Execute with Linux PAL (:program:`gramine-direct`)
+--------------------------------------------------
 
-You may select the Linux PAL at Docker run time instead of the Linux-SGX PAL by
-specifying the environment variable :envvar:`GSC_PAL` as an option to the
-:command:`docker run` command. When using the Linux PAL, it is not necessary to
-sign the image via a :command:`gsc sign-image` command.
+You may select the Linux PAL (:program:`gramine-direct`) at Docker run time
+instead of the Linux-SGX PAL (:program:`gramine-sgx`) by specifying the
+environment variable :envvar:`GSC_PAL` as an option to the
+:command:`docker run` command. When using the Linux PAL, it is not necessary
+to sign the image via a :command:`gsc sign-image` command.
 
 .. envvar:: GSC_PAL
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Sometimes users have difficulty in finding the command to run the workload in `gramine-direct` in GSC. This change should make it easy to understand the command used for running workload in `gramine-direct`.

## How to test this PR? <!-- (if applicable) -->

NA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/182)
<!-- Reviewable:end -->
