### PR TITLE
Drop support for TOML-dict syntax for files in manifest

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -355,22 +355,6 @@ def gsc_build(args):
             print(f'Failed to parse the "{args.manifest}" file. Error:', e, file=sys.stderr)
             sys.exit(1)
 
-    # Support deprecated syntax: replace old-style TOML-dict (`sgx.trusted_files.key = "file:foo"`)
-    # with new-style TOML-array (`sgx.trusted_files = ["file:foo"]`) in the user manifest
-    if 'sgx' in user_manifest_dict:
-        if 'trusted_files' in user_manifest_dict['sgx']:
-            if isinstance(user_manifest_dict['sgx']['trusted_files'], dict):
-                tf_list = list(user_manifest_dict['sgx']['trusted_files'].values())
-                user_manifest_dict['sgx']['trusted_files'] = tf_list
-        if 'allowed_files' in user_manifest_dict['sgx']:
-            if isinstance(user_manifest_dict['sgx']['allowed_files'], dict):
-                af_list = list(user_manifest_dict['sgx']['allowed_files'].values())
-                user_manifest_dict['sgx']['allowed_files'] = af_list
-        if 'protected_files' in user_manifest_dict['sgx']:
-            if isinstance(user_manifest_dict['sgx']['protected_files'], dict):
-                pf_list = list(user_manifest_dict['sgx']['protected_files'].values())
-                user_manifest_dict['sgx']['protected_files'] = pf_list
-
     merged_manifest_dict = merge_two_dicts(user_manifest_dict, entrypoint_manifest_dict)
     merged_manifest_dict = merge_two_dicts(merged_manifest_dict, base_image_dict)
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

GSC still supports below mentioned very old style syntax:
```
    sgx.allowed_files.[identifier] = "[URI]"
    sgx.trusted_files.[identifier] = "[URI]"
    sgx.protected_files.[identifier] = "[URI]"
```
Examples:
```
sgx.trusted_files.mysqld = "file:/var/run/mysqld/"
sgx.trusted_files.tmp = "file:/tmp/"
```

This was dropped in Gramine v1.2 release with PR [374](https://github.com/gramineproject/gramine/pull/374). This PR drops the support for the same.

## How to test this PR? <!-- (if applicable) -->

Add the old style syntax as mentioned above in the user manifest and test with and without this PR. Old style syntax should work without this PR but should fail with this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/185)
<!-- Reviewable:end -->
