### PR TITLE
Retain `openssl` during signing in `redhat/ubi8-minimal`

### DIFF
--- a/templates/redhat/ubi8-minimal/Dockerfile.build.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.build.template
@@ -10,7 +10,6 @@ COPY redhat-uep.pem /etc/rhsm/ca/
 # final image. This trick allows to decrease the image size by hundreds of MBs.
 RUN rm -rf /etc/rhsm-host \
     && rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && microdnf update -y \
     && microdnf install -y subscription-manager \
     && subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
     && microdnf install -y \

--- a/templates/redhat/ubi8-minimal/Dockerfile.compile.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.compile.template
@@ -8,7 +8,6 @@ COPY redhat-uep.pem /etc/rhsm/ca/
 # NOTE: meson v1.2.* has a bug that leads to Gramine build failure because of not found `libcurl.a`
 RUN rm -rf /etc/rhsm-host \
     && rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-    && microdnf update -y \
     && microdnf install -y subscription-manager \
     && subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms \
     && microdnf install -y \

--- a/templates/redhat/ubi8-minimal/Dockerfile.sign.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.sign.template
@@ -1,12 +1,14 @@
 {% extends "Dockerfile.common.sign.template" %}
 
+# Ideally, we would want to remove `openssl` and all its dependencies, but because of the slight
+# differences between different `openssl` package versions, it is hard to do in a uniform way (as
+# `openssl` installation may install additional packages).
 {% block uninstall %}
 RUN \
        pip3 uninstall -y click jinja2 \
           tomli tomli-w \
        && microdnf remove -y binutils \
           epel-release \
-          openssl \
           python3-cryptography \
           python3-protobuf \
           python3-pyelftools \


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Avoid uninstalling `openssl` during signing in `redhat/ubi8-minimal`. Ideally we would want to remove `openssl` and all its dependencies, but because of the slight differences between different `openssl` package versions, it is hard to do in a uniform way (as `openssl` installation may install additional packages). And removing `openssl` doesn't help with minimizing the image size too much.

Also, unlike other distros like `ubuntu` with `apt update` the `microdnf update` command updates and upgrades new/existing packages. The `microdnf update` command can be removed from templates as installing new package updates metadata and gets latest information about the package. 

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Follow the steps mentioned in #187 to test this PR
Fixes #187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/188)
<!-- Reviewable:end -->
