### PR TITLE
Set correct permissions of `/tmp` dir during GSC build

### DIFF
--- a/templates/Dockerfile.common.build.template
+++ b/templates/Dockerfile.common.build.template
@@ -11,6 +11,10 @@ FROM {{app_image}}
 # Temporarily switch to the root user to install packages
 USER root
 
+# Reset the correct permissions of /tmp dir (original app image may have changed it, and correct
+# permissions are required for installation of packages)
+RUN chmod 1777 /tmp
+
 # Install distro-specific packages to run Gramine (e.g., python3, protobuf, tomli, etc.)
 {% block install %}{% endblock %}
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The original app image may have changed the permissions of `/tmp` dir. At the same time, correct permissions are required for installation of packages during GSC build. This commit adds explicit `chmod 1777 /tmp`.

Fixes #193.

## How to test this PR? <!-- (if applicable) -->

Looks like a reproducer would be like this:
```
FROM debian:12
RUN chmod 1777 /tmp
USER ${non_root_uid}:${non_root_gid}
```

But I haven't tested really.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/194)
<!-- Reviewable:end -->
