### PR TITLE
Add `python3-voluptuous` dependency in Dockerfile templates

### DIFF
--- a/templates/centos/Dockerfile.build.template
+++ b/templates/centos/Dockerfile.build.template
@@ -18,6 +18,7 @@ RUN dnf update -y \
         python3-cryptography \
         python3-pip \
         python3-protobuf \
+        python3-voluptuous \
     && /usr/bin/python3 -B -m pip install click jinja2 protobuf \
                                           'tomli>=1.1.0' 'tomli-w>=0.4.0' \
     && dnf repolist \

--- a/templates/centos/Dockerfile.sign.template
+++ b/templates/centos/Dockerfile.sign.template
@@ -7,9 +7,10 @@ RUN \
        && dnf remove -y binutils \
           epel-release \
           openssl \
+          python3-cryptography \
           python3-protobuf \
           python3-pyelftools \
-          python3-cryptography \
+          python3-voluptuous \
           tcl \
        && dnf -y clean all;
 {% endblock %}

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -15,6 +15,7 @@ RUN apt-get update \
         python3-cryptography \
         python3-protobuf \
         python3-pyelftools \
+        python3-voluptuous \
 # Debian 12 and Ubuntu 23.04 adopted PEP 668, which dictates that `pip` can no longer install
 # packages managed by the distro's general-purpose package manager, hence we use `apt-get`
         {%- if (distro[0] == "debian" and distro[1] | int >= 12) or

--- a/templates/debian/Dockerfile.sign.template
+++ b/templates/debian/Dockerfile.sign.template
@@ -5,9 +5,10 @@
 RUN \
         apt-get remove -y binutils \
         openssl \
-        python3-protobuf \
         python3-cryptography \
+        python3-protobuf \
         python3-pyelftools \
+        python3-voluptuous \
 # please see the comment in Dockerfile.build.template for explanation why this condition is needed
         {%- if (distro[0] == "debian" and distro[1] | int >= 12) or
                (distro[0] == "ubuntu" and distro[1] | int >= 23) %}

--- a/templates/redhat/ubi8-minimal/Dockerfile.build.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.build.template
@@ -23,6 +23,7 @@ RUN rm -rf /etc/rhsm-host \
         python3-pip \
         python3-protobuf \
         python3-pyelftools \
+        python3-voluptuous \
         wget \
         which \
     && /usr/bin/python3 -B -m pip install click jinja2 \

--- a/templates/redhat/ubi8-minimal/Dockerfile.sign.template
+++ b/templates/redhat/ubi8-minimal/Dockerfile.sign.template
@@ -12,6 +12,7 @@ RUN \
           python3-cryptography \
           python3-protobuf \
           python3-pyelftools \
+          python3-voluptuous \
        && microdnf -y clean all;
 {% endblock %}
 

--- a/templates/redhat/ubi8/Dockerfile.build.template
+++ b/templates/redhat/ubi8/Dockerfile.build.template
@@ -22,6 +22,7 @@ RUN rm -rf /etc/rhsm-host \
         python3-pip \
         python3-protobuf \
         python3-pyelftools \
+        python3-voluptuous \
         wget \
     && /usr/bin/python3 -B -m pip install click jinja2 \
                                           'tomli>=1.1.0' 'tomli-w>=0.4.0' \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

[Commit "[python] Add gramine-manifest-check tool"](https://github.com/gramineproject/gramine/commit/2427c73061039bda26bbd2e12dff23157d8886c3) in the core Gramine repository adds a new tool that depends on the `python3-voluptuous` package. GSC thus has an indirect dependency on this package, so we need to add it to the list of deps in all Dockerfile templates.

The problem happened because of this indirect dependency on voluptuous:

- `gramine-sgx-sign` imports `manifest`: https://github.com/gramineproject/gramine/blob/f1258cc003a649e2b0c5b805b739160cbd72cfcf/python/gramine-sgx-sign#L15-L17
- `manifest` imports `manifest_check`: https://github.com/gramineproject/gramine/blob/f1258cc003a649e2b0c5b805b739160cbd72cfcf/python/graminelibos/manifest.py#L23
- `manifest_check` imports `voluptuous`: https://github.com/gramineproject/gramine/blob/f1258cc003a649e2b0c5b805b739160cbd72cfcf/python/graminelibos/manifest_check.py#L5C6-L5C17

## How to test this PR? <!-- (if applicable) -->

- Without this PR:
```
~/gramineproject/gsc$ ./gsc sign-image python:bullseye enclave-key.pem
...
Step 6/9 : RUN export PYTHONPATH="${PYTHONPATH}:$(find /gramine/meson_build_output/lib -type d -path '*/site-packages')" && gramine-sgx-sign       --key /gramine/app_files/gsc-signer-key.pem       --manifest /gramine/app_files/entrypoint.manifest       --output /gramine/app_files/entrypoint.manifest.sgx       ${passphrase:+--passphrase "$passphrase"}

 ---> Running in e57dabfc4969
Traceback (most recent call last):
  File "/gramine/meson_build_output/bin/gramine-sgx-sign", line 15, in <module>
    from graminelibos import (
  File "/gramine/meson_build_output/lib/python3.9/site-packages/graminelibos/__init__.py", line 22, in <module>
    from .manifest import Manifest, ManifestError
  File "/gramine/meson_build_output/lib/python3.9/site-packages/graminelibos/manifest.py", line 23, in <module>

    from .manifest_check import GramineManifestSchema
  File "/gramine/meson_build_output/lib/python3.9/site-packages/graminelibos/manifest_check.py", line 5, in <module>

    from voluptuous import (
ModuleNotFoundError: No module named 'voluptuous'

Removing intermediate container e57dabfc4969
Failed to build a signed graminized Docker image `gsc-python:bullseye`.
```

- With this PR:
```
~/gramineproject/gsc$ ./gsc sign-image python:bullseye enclave-key.pem
...
Successfully tagged gsc-python:bullseye
Successfully built a signed Docker image `gsc-python:bullseye` from `gsc-python:bullseye-unsigned`.
```