### PR TITLE
WIP Add support for Gramine-TDX

### DIFF
--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -29,7 +29,7 @@ RUN mkdir -p /gramine/driver/asm \
 RUN cd /gramine \
     && meson setup build/ --prefix="/gramine/meson_build_output" \
        --buildtype={{buildtype}} \
-       -Ddirect=enabled -Dsgx=enabled \
+       -Ddirect=enabled -Dsgx=enabled -Dvm=enabled \
        {% if Distro.startswith('ubuntu') %}-Ddcap=enabled{% endif %} \
        {% if "linux-sgx-driver" in SGXDriver.Repository %} \
        -Dsgx_driver=oot -Dsgx_driver_include_path=/gramine/driver \

--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -14,6 +14,11 @@ then
     exec gramine-sgx /gramine/app_files/entrypoint \
         {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
         "${@}"{% endif %}
+elif [ "$GSC_PAL" == "VM" ]
+then
+    exec gramine-vm /gramine/app_files/entrypoint \
+        {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
+        "${@}"{% endif %}
 else
     exec gramine-direct /gramine/app_files/entrypoint \
     {{ binary_arguments | map('shlex_quote') | join(' ') }} "${@}"

--- a/templates/debian/Dockerfile.build.template
+++ b/templates/debian/Dockerfile.build.template
@@ -5,6 +5,10 @@
 # Combine all installation and removal steps in a single RUN command to reduce the final image size.
 # This is because each Dockerfile command creates a new layer which necessarily adds size to the
 # final image. This trick allows to decrease the image size by hundreds of MBs.
+#
+# For Gramine-TDX, need socat and virtiofsd. The former can be installed in Ubuntu 22.04 and later
+# (we need at least v1.7.4). The latter can't be installed in most Ubuntu versions, so install
+# manually by downloading the zip archive and copying.
 RUN apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         binutils \
@@ -14,8 +18,13 @@ RUN apt-get update \
         python3 \
         python3-cryptography \
         python3-protobuf \
+        python3-psutil \
         python3-pyelftools \
         python3-voluptuous \
+        qemu-kvm \
+        socat \
+        unzip \
+        wget \
 # Debian 12 and Ubuntu 23.04 adopted PEP 668, which dictates that `pip` can no longer install
 # packages managed by the distro's general-purpose package manager, hence we use `apt-get`
         {%- if (distro[0] == "debian" and distro[1] | int >= 12) or
@@ -33,6 +42,18 @@ RUN apt-get update \
         {%- endif %}
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/qemu-system-x86_64 /usr/local/bin/qemu
+
+RUN mkdir -p /gramine/virtiofsd \
+    && mkdir -p /usr/local/bin \
+    && cd /gramine/virtiofsd \
+    && wget --timeout=10 -O virtiofsd.zip \
+        https://gitlab.com/virtio-fs/virtiofsd/uploads/2cf9068046720699531407101f2bcb60/virtiofsd-v1.10.1.zip \
+    && sha256sum virtiofsd.zip | grep -q 8166b47d80ed16cc6df4bfd350063e98f70039a212d10cc5c1ea99251dbd2945 \
+    && unzip virtiofsd.zip \
+    && cp target/x86_64-unknown-linux-musl/release/virtiofsd /usr/local/bin/ \
+    && rm virtiofsd.zip
 
 {% if buildtype != "release" %}
 RUN apt-get update \

--- a/test/README.rst
+++ b/test/README.rst
@@ -44,3 +44,32 @@ version of the Intel SGX driver if needed):
    docker run --device=/dev/sgx_enclave \
       -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
       gsc-ubuntu20.04-bash -c ls
+
+Building for Gramine-TDX
+------------------------
+
+Note that we need at least Ubuntu 22.04.
+
+.. code-block:: sh
+
+   docker build --tag ubuntu22.04-hello-world --file test/ubuntu22.04-hello-world.dockerfile .
+
+   ./gsc build --buildtype debug ubuntu22.04-hello-world test/ubuntu22.04-hello-world.manifest
+   ./gsc sign-image ubuntu22.04-hello-world enclave-key.pem
+
+   docker run --env GSC_PAL=VM --security-opt seccomp=unconfined \
+       --shm-size 4G --env GRAMINE_CPU_NUM=1 \
+       --device=/dev/vhost-vsock:/dev/vhost-vsock \
+       --device=/dev/kvm:/dev/kvm --group-add `getent group kvm | cut -d: -f3` \
+       gsc-ubuntu22.04-hello-world
+   # or to peek into the image
+   docker run -it --entrypoint /bin/bash gsc-ubuntu22.04-hello-world
+
+Note that in ``docker run``, we must specify the following:
+
+- ``--shm-size 4G`` -- our QEMU/KVM uses ``/dev/shm`` for virtio-fs shared
+  memory. However, Docker containers start with 64MB by default. Thus, we need
+  to explicitly specify the shared memory limit. ``4G`` is just an example; this
+  limit depends on the app running inside Gramine-TDX.
+- ``--env GRAMINE_CPU_NUM=1`` -- this instructs QEMU to spawn a Gramine-TDX VM
+  with 1 vCPU. Modify this to have more vCPUs.

--- a/test/ubuntu22.04-hello-world.dockerfile
+++ b/test/ubuntu22.04-hello-world.dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+
+CMD ["echo", "\"Hello World! Let's check escaped symbols: < & > \""]

--- a/test/ubuntu22.04-hello-world.manifest
+++ b/test/ubuntu22.04-hello-world.manifest
@@ -1,0 +1,1 @@
+# intentionally left empty so that GSC uses default manifest options


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

**This is Work In Progress, adding support for https://github.com/gramineproject/gramine-tdx**

Currently only Gramine-VM. I'll update with Gramine-TDX in the next iteration. Need to think how to automatically start socat for virtio-vsock networking.

## How to test this PR? <!-- (if applicable) -->

README is updated with instructions.