### PR TITLE
Deprecate `GSC_PAL` and use instead `GRAMINE_MODE`

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -396,26 +396,27 @@ executable arguments may be supplied to the :command:`docker run` command.
    :command:`gsc build`.
 
 
-Execute with Linux PAL (:program:`gramine-direct`)
---------------------------------------------------
+Execute with :program:`gramine-direct`
+--------------------------------------
 
-You may select the Linux PAL (:program:`gramine-direct`) at Docker run time
-instead of the Linux-SGX PAL (:program:`gramine-sgx`) by specifying the
-environment variable :envvar:`GSC_PAL` as an option to the
-:command:`docker run` command. When using the Linux PAL, it is not necessary
-to sign the image via a :command:`gsc sign-image` command.
+By default, the Docker container starts :program:`gramine-sgx`.
 
-.. envvar:: GSC_PAL
+You may choose to start :program:`gramine-direct` in the Docker container by
+specifying the environment variable :envvar:`GRAMINE_MODE` as a command-line
+option to :command:`docker run`.
 
-   This environment variable specifies the pal loader.
+.. envvar:: GRAMINE_MODE
 
-GSC requires a custom seccomp profile while running with Linux PAL, which has to be
-specified at Docker run time. There are two options:
+   This environment variable specifies the mode of Gramine to run. Currently
+   supported values are ``direct`` and ``sgx``. Default is ``sgx``.
+
+GSC requires a custom seccomp profile for the ``direct`` mode. There are two
+options:
 
 #. Pass `unconfined` to run the container without the default seccomp profile.
    This option is generally considered insecure, since this results in containers
    running with unrestricted system calls (all system calls are allowed which
-   increases the attack surface of the Linux Kernel).
+   increases the attack surface of the Linux kernel).
 
 #. Pass the custom seccomp profile
    https://github.com/gramineproject/gramine/blob/master/scripts/docker_seccomp.json.
@@ -426,7 +427,13 @@ specified at Docker run time. There are two options:
 
 .. code-block:: sh
 
-   docker run ... --env GSC_PAL=Linux --security-opt seccomp=<profile> gsc-<image-name> ...
+   docker run ... --env GRAMINE_MODE=direct \
+       --security-opt seccomp=<profile> \
+       gsc-<image-name> ...
+
+.. note::
+    Previously, to run in ``direct`` mode, one specified ``--env
+    GSC_PAL=Linux``. This is deprecated in GSC v1.8 and will be removed in v1.9.
 
 Example
 =======

--- a/templates/apploader.common.template
+++ b/templates/apploader.common.template
@@ -8,13 +8,38 @@ set -e
 # Export distro-specific paths (typically `PYTHONPATH` and `PKG_CONFIG_PATH`)
 {% block path %}{% endblock %}
 
-# Default to Linux-SGX if no PAL was specified
-if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
-then
-    exec gramine-sgx /gramine/app_files/entrypoint \
-        {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
-        "${@}"{% endif %}
-else
-    exec gramine-direct /gramine/app_files/entrypoint \
-    {{ binary_arguments | map('shlex_quote') | join(' ') }} "${@}"
+# Note: default to SGX if Gramine mode (`direct`, `sgx`) wasn't specified
+GRAMINE_EXEC=gramine-sgx
+
+# TODO: remove GSC_PAL in GSC v1.9
+if [ -n "$GSC_PAL" ] && [ -n "$GRAMINE_MODE" ]; then
+    echo "ERROR: GSC_PAL and GRAMINE_MODE environment variables cannot be set together."
+    exit 1
 fi
+
+if [ -n "$GSC_PAL" ]; then
+    echo "WARNING: GSC_PAL environment variable is deprecated in v1.8 and will be removed in v1.9."
+    echo "         Instead, use GRAMINE_MODE={direct|sgx}."
+
+    # legacy logic was peculiar: if GSC_PAL != Linux-SGX then we set Gramine to `gramine-direct`
+    if [ "$GSC_PAL" == "Linux-SGX" ]; then
+        GRAMINE_EXEC=gramine-sgx
+    else
+        GRAMINE_EXEC=gramine-direct
+    fi
+fi
+
+if [ -n "$GRAMINE_MODE" ]; then
+    if [ "$GRAMINE_MODE" == "sgx" ]; then
+        GRAMINE_EXEC=gramine-sgx
+    elif [ "$GRAMINE_MODE" == "direct" ]; then
+        GRAMINE_EXEC=gramine-direct
+    else
+        echo "ERROR: unrecognized GRAMINE_MODE; can only be 'direct' or 'sgx'."
+        exit 1
+    fi
+fi
+
+exec ${GRAMINE_EXEC} /gramine/app_files/entrypoint \
+    {% if insecure_args %}{{ binary_arguments | map('shlex_quote') | join(' ') }} \
+    "${@}"{% endif %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, to run `gramine-direct`, one had to specify `docker run ... --env GSC_PAL=Linux`. This was cumbersome because (1) Gramine users don't need to know the meaning of word "PAL", (2) the value "Linux" doesn't correspond to known-to-users `gramine-direct`, (3) it requires special logic in apploader code.

This PR introduces instead ~~`GSC_GRAMINE_BINARY`~~ ~~`GRAMINE_BINARY`~~ `GRAMINE_MODE` envvar with easier semantics: the value is the mode (`direct` or `sgx`) which user wants to invoke.

Extracted from #199. 

## How to test this PR? <!-- (if applicable) -->

Manually run e.g. the HelloWorld example. After GSC build & sign, you can try:
```sh
$ docker run \
  --security-opt seccomp=unconfined \
  --env GRAMINE_MODE=direct \
  gsc-ubuntu20.04-hello-world
"Hello World! Let's check escaped symbols: < & > "

sdp@sdp:~/tdx/gsc$ docker run \
  --device=/dev/sgx_enclave -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
  --env GRAMINE_MODE=sgx \
  gsc-ubuntu20.04-hello-world
Gramine is starting. Parsing TOML manifest file, this may take some time...
"Hello World! Let's check escaped symbols: < & > "

sdp@sdp:~/tdx/gsc$ docker run \
  --device=/dev/sgx_enclave \
  -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
  gsc-ubuntu20.04-hello-world
Gramine is starting. Parsing TOML manifest file, this may take some time...
"Hello World! Let's check escaped symbols: < & > "

sdp@sdp:~/tdx/gsc$ docker run \
  --env GRAMINE_MODE=bla \
  gsc-ubuntu20.04-hello-world
/gramine/app_files/apploader.sh: line 16: exec: gramine-bla: not found
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/201)
<!-- Reviewable:end -->
