### PR TITLE
Add multiprocessing lock in prune Docker images

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -6,6 +6,7 @@
 
 import argparse
 import hashlib
+import multiprocessing
 import os
 import pathlib
 import re
@@ -521,7 +522,9 @@ def gsc_sign_image(args):
         os.remove(tmp_build_key_path)
         # Remove a temporary image created during multistage docker build to save disk space.
         # Please note that removing the image doesn't assure security.
-        docker_socket.api.prune_images(filters={'label': 'build_id=' + build_id})
+        lock = multiprocessing.Lock()
+        with lock:
+            docker_socket.api.prune_images(filters={'label': 'build_id=' + build_id})
 
     if get_docker_image(docker_socket, signed_image_name) is None:
         print(f'Failed to build a signed graminized Docker image `{signed_image_name}`.')


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR adds a lock to the Docker image pruning process to prevent race conditions and breaking the code
<!-- If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

To test this PR, create a script that signs multiple images in parallel in background using `&`. Then, attempt to trigger the race condition while performing the `gsc sign` operation. This should help you encounter the issue.
Example script [Link](https://gist.github.com/adarshan-intel/97a1e7d1bce956f8fb7015438d9bda24)

![image](https://github.com/user-attachments/assets/5a5510b9-3700-4501-be7b-603e19ba05b7)

Adding locking mechanism should fix the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/208)
<!-- Reviewable:end -->
