### PR TITLE
Add cmake build dependency

### DIFF
--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -10,6 +10,7 @@ RUN dnf update -y \
     &&  dnf install -y \
         autoconf \
         bison \
+        cmake \
         curl \
         elfutils-libelf-devel \
         epel-release \

--- a/templates/centos/stream/Dockerfile.compile.template
+++ b/templates/centos/stream/Dockerfile.compile.template
@@ -11,6 +11,7 @@ RUN dnf distro-sync -y \
         autoconf  \
         binutils \
         bison \
+        cmake \
         epel-release \
         flex \
         gawk \

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -8,6 +8,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         autoconf \
         bison \
         build-essential \
+        cmake \
         coreutils \
         curl \
         gawk \

--- a/templates/redhat/ubi-minimal/Dockerfile.compile.template
+++ b/templates/redhat/ubi-minimal/Dockerfile.compile.template
@@ -18,6 +18,7 @@ RUN rm -rf /etc/rhsm-host \
     && microdnf install -y \
         autoconf \
         bison \
+        cmake \
         elfutils-libelf-devel \
         flex \
         gawk \

--- a/templates/redhat/ubi/Dockerfile.compile.template
+++ b/templates/redhat/ubi/Dockerfile.compile.template
@@ -18,6 +18,7 @@ RUN rm -rf /etc/rhsm-host \
     && dnf install -y \
         autoconf \
         bison \
+        cmake \
         elfutils-libelf-devel \
         flex \
         gawk \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit ["[tools/sgx] Modify RA-TLS to adhere to Interoperable RA-TLS standard"](https://github.com/gramineproject/gramine/commit/71fa288885d3fd8d8d23ca88156c69957c055c43) in core Gramine repository introduced the cmake dependency for Gramine build. This commit adds it to GSC build templates.

Fixes #209.

## How to test this PR? <!-- (if applicable) -->

Build GSC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/210)
<!-- Reviewable:end -->
