### PR TITLE
Fix installation of Gramine DCAP support on Ubuntu

### DIFF
--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -30,7 +30,7 @@ RUN cd /gramine \
     && meson setup build/ --prefix="/gramine/meson_build_output" \
        --buildtype={{buildtype}} \
        -Ddirect=enabled -Dsgx=enabled \
-       {% if template_path(Distro) == 'ubuntu' %}-Ddcap=enabled{% endif %} \
+       {% if template_path(Distro).startswith('ubuntu:') %}-Ddcap=enabled{% endif %} \
        {% if "linux-sgx-driver" in SGXDriver.Repository %} \
        -Dsgx_driver=oot -Dsgx_driver_include_path=/gramine/driver \
        {% else %} \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit 7620ef04 "Add support for SLES 15 SP4" introduced a bug in `Dockerfile.common.compile.template`. Instead of enabling Gramine DCAP support when the distro name starts with "ubuntu", the commit changed it to exactly equal to "ubuntu". This resulted in Gramine DCAP support always being disabled because `template_path(Distro)` returned strings like "ubuntu:22.04".

Fixes #213 

## How to test this PR? <!-- (if applicable) -->

Try any Ubuntu distro.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/216)
<!-- Reviewable:end -->
