### PR TITLE
[Doc] Remove temporary workaround of venv usage for Ubuntu 24.04

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -54,25 +54,13 @@ pip. GSC requires Python 3.6 or later.
    sudo apt-get install docker.io python3 python3-pip
    pip3 install docker jinja2 tomli tomli-w pyyaml
 
-Python venv workaround for Ubuntu 24.04
----------------------------------------
-
-Unfortunately, Ubuntu 24.04 (noble) has a `bug that prevents out-of-the-box
-execution of
-GSC <https://bugs.launchpad.net/ubuntu/+source/python-docker/+bug/2065348>`__.
-
-Until this bug is fixed, GSC must be run on Ubuntu 24.04 via Python virtual
-environment (venv). Please perform the following steps to install and activate
-venv for GSC:
+For Ubuntu 24.04:
 
 .. code-block:: sh
 
-   sudo apt-get install python3-venv
-   python3 -m venv my_venv && source my_venv/bin/activate
-   pip3 install 'docker>=6.1.0' jinja2 tomli tomli-w pyyaml
-
-Now you can execute GSC commands (`gsc build`, `gsc sign`, etc.) as usual,
-within the virtual environment confines.
+   sudo apt update && sudo apt install -y docker.io python3 \
+      'python3-docker=5.0.3-1ubuntu1.1' python3-jinja2 python3-toml \
+      python3-tomli-w python3-yaml
 
 SGX software stack
 ------------------


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html 
-->

## Description of the changes <!-- (reasons and measures) -->
The fix for the issue reported in #202 has been upstreamed. This PR removes the previous workaround involving virtual environments (venv) for Ubuntu 24.04, which was necessary due to compatibility issues with the Docker SDK for Python.

Users running Ubuntu 24.04 are now instructed to follow the updated docs to install packages for `gsc build` and `sign` commands.

This workaround was proposed to be removed once the `python3-docker` package was fixed via updates, and since Ubuntu 24.04 has received this fix, we are now removing it.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. 
-->
Fixes #202 

## How to test this PR? <!-- (if applicable) -->
Run the `gsc build` and `gsc sign` commands.