### PR TITLE
Remove `loader.entrypoint` from manifest template

### DIFF
--- a/templates/centos/entrypoint.manifest.template
+++ b/templates/centos/entrypoint.manifest.template
@@ -1,6 +1,5 @@
 {% extends "entrypoint.common.manifest.template" %}
 
 {% block loader %}
-loader.entrypoint = "file:/gramine/meson_build_output/lib64/gramine/libsysdb.so"
 loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib64/gramine/runtime/glibc:/usr/lib64:{{"{{library_paths}}"}}"
 {% endblock %}

--- a/templates/debian/entrypoint.manifest.template
+++ b/templates/debian/entrypoint.manifest.template
@@ -1,8 +1,6 @@
 {% extends "entrypoint.common.manifest.template" %}
 
 {% block loader %}
-loader.entrypoint = "file:/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/libsysdb.so"
-
 # Add "/usr/lib/x86_64-linux-gnu" explicitly because ldconfig in Ubuntu 21.04 doesn't
 # produce it; note that this Debian template is used by Ubuntu templates as well
 loader.env.LD_LIBRARY_PATH = "/gramine/meson_build_output/lib/x86_64-linux-gnu/gramine/runtime/glibc:/usr/lib/x86_64-linux-gnu:{{"{{library_paths}}"}}"

--- a/templates/entrypoint.common.manifest.template
+++ b/templates/entrypoint.common.manifest.template
@@ -1,6 +1,6 @@
 libos.entrypoint = "/gramine/app_files/{{binary_basename}}"
 
-# Add distro-specific `loader.entrypoint` and `loader.env.LD_LIBRARY_PATH`
+# Add distro-specific `loader.env.LD_LIBRARY_PATH`
 {% block loader %}{% endblock %}
 
 loader.env.PATH = "{{"{{env_path}}"}}"


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This is a commit corresponding to commit 87c752f "[PAL] Drop deprecated syntax of loader.entrypoint" in core Gramine repository.

Fixes https://github.com/gramineproject/gsc/issues/224.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Manual testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/225)
<!-- Reviewable:end -->
