### PR TITLE
Update GSC with Gramine's new SGX driver requirements

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -359,16 +359,6 @@ in :file:`config.yaml.template`.
    provided for popular cloud-provider environments. `Gramine.Repository` and
    `Gramine.Branch` are ignored in case `Gramine.Image` is specified.
 
-.. describe:: SGXDriver.Repository
-
-   Source repository of the Intel SGX driver. Default value: ""
-   (in-kernel driver).
-
-.. describe:: SGXDriver.Branch
-
-   Use this branch of the repository. Default value: ""
-   (in-kernel driver).
-
 Run graminized Docker images
 =============================
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -32,22 +32,3 @@ Registry: ""
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
     Branch:     "master"
-
-# Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
-# the graminized Docker container will run); there are several variants of the SGX driver:
-#
-#   - upstream (in-kernel) driver: use empty values like below
-#         Repository: ""
-#         Branch:     ""
-#
-#   - DCAP out-of-tree driver: same as above, use empty values
-#         Repository: ""
-#         Branch:     ""
-#
-#   - legacy out-of-tree driver: use something like the below values, but adjust the branch name
-#         Repository: "https://github.com/01org/linux-sgx-driver.git"
-#         Branch:     "sgx_driver_1.9"
-#
-SGXDriver:
-    Repository: ""
-    Branch:     ""

--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -13,28 +13,10 @@ RUN cd /gramine \
     && git fetch origin {{Gramine.Branch}} \
     && git checkout {{Gramine.Branch}}
 
-{% if "linux-sgx-driver" in SGXDriver.Repository %}
-RUN cd /gramine \
-    && git clone {{SGXDriver.Repository}} driver \
-    && cd driver \
-    && git checkout {{SGXDriver.Branch}}
-{% else %}
-RUN mkdir -p /gramine/driver/asm \
-    && cd /gramine/driver/asm \
-    && wget --timeout=10 -O sgx.h \
-        https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/arch/x86/include/uapi/asm/sgx.h?h=v5.11 \
-    && sha256sum sgx.h | grep -q a34a997ade42b61376b1c5d3d50f839fd28f2253fa047cb9c0e68a1b00477956
-{% endif %}
-
 RUN cd /gramine \
     && meson setup build/ --prefix="/gramine/meson_build_output" \
        --buildtype={{buildtype}} \
        -Ddirect=enabled -Dsgx=enabled \
        {% if template_path(Distro).startswith('ubuntu:') %}-Ddcap=enabled{% endif %} \
-       {% if "linux-sgx-driver" in SGXDriver.Repository %} \
-       -Dsgx_driver=oot -Dsgx_driver_include_path=/gramine/driver \
-       {% else %} \
-       -Dsgx_driver=upstream -Dsgx_driver_include_path=/gramine/driver \
-       {% endif %} \
     && ninja -C build \
     && ninja -C build install

--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -19,6 +19,7 @@ RUN dnf update -y \
         gcc-c++ \
         git \
         httpd \
+        kernel-headers \
         libevent-devel \
         make \
         nasm \
@@ -36,7 +37,6 @@ RUN dnf update -y \
         python3-pip \
         python3-protobuf \
         rpm-build \
-        wget \
     && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
 
 {% endblock %}

--- a/templates/centos/stream/Dockerfile.compile.template
+++ b/templates/centos/stream/Dockerfile.compile.template
@@ -18,6 +18,7 @@ RUN dnf distro-sync -y \
         gcc-c++ \
         git \
         httpd \
+        kernel-headers \
         libcurl-devel \
         make \
         nasm \
@@ -36,7 +37,6 @@ RUN dnf distro-sync -y \
         python3-pip \
         python3-protobuf \
         rpm-build \
-        wget \
         yum-utils \
     && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
 

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -3,6 +3,14 @@
 # NOTE: meson v1.2.* has a bug that leads to Gramine build failure because of not found `libcurl.a`
 {% block install %}
 {% set distro = Distro.split(':') %}
+
+{%- if distro[0] == "debian" and distro[1] | int == 11 %}
+# linux-libc-dev providing sgx.h is available in the debian bullseye-backports repo for debian 11
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list \
+    && env DEBIAN_FRONTEND=noninteractive apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install -y -t bullseye-backports linux-libc-dev
+{%- endif %}
+
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
         autoconf \
@@ -14,7 +22,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         gawk \
         git \
         libprotobuf-c-dev \
-        linux-headers-generic \
+        linux-libc-dev \
         nasm \
         ninja-build \
         pkg-config \
@@ -23,7 +31,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         python3 \
         python3-cryptography \
         python3-protobuf \
-        wget \
 # please see the comment in Dockerfile.build.template for explanation why this condition is needed
         {%- if (distro[0] == "debian" and distro[1] | int >= 12) or
                (distro[0] == "ubuntu" and distro[1] | int >= 23) %}

--- a/templates/redhat/ubi-minimal/Dockerfile.build.template
+++ b/templates/redhat/ubi-minimal/Dockerfile.build.template
@@ -29,7 +29,6 @@ RUN rm -rf /etc/rhsm-host \
         python3-protobuf \
         python3-pyelftools \
         python3-voluptuous \
-        wget \
         which \
     && /usr/bin/python3 -B -m pip install click jinja2 \
                                           'tomli>=1.1.0' 'tomli-w>=0.4.0' \

--- a/templates/redhat/ubi-minimal/Dockerfile.compile.template
+++ b/templates/redhat/ubi-minimal/Dockerfile.compile.template
@@ -25,6 +25,7 @@ RUN rm -rf /etc/rhsm-host \
         gcc-c++ \
         git \
         httpd \
+        kernel-headers \
         libevent-devel \
         make \
         nasm \
@@ -43,7 +44,6 @@ RUN rm -rf /etc/rhsm-host \
         python3-protobuf \
         python3-voluptuous \
         rpm-build \
-        wget \
     && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
 
 {% endblock %}

--- a/templates/redhat/ubi/Dockerfile.build.template
+++ b/templates/redhat/ubi/Dockerfile.build.template
@@ -28,7 +28,6 @@ RUN rm -rf /etc/rhsm-host \
         python3-protobuf \
         python3-pyelftools \
         python3-voluptuous \
-        wget \
     && /usr/bin/python3 -B -m pip install click jinja2 \
                                           'tomli>=1.1.0' 'tomli-w>=0.4.0' \
     && dnf repolist \

--- a/templates/redhat/ubi/Dockerfile.compile.template
+++ b/templates/redhat/ubi/Dockerfile.compile.template
@@ -25,6 +25,7 @@ RUN rm -rf /etc/rhsm-host \
         gcc-c++ \
         git \
         httpd \
+        kernel-headers \
         libevent-devel \
         make \
         nasm \
@@ -43,7 +44,6 @@ RUN rm -rf /etc/rhsm-host \
         python3-protobuf \
         python3-voluptuous \
         rpm-build \
-        wget \
     && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
 
 {% endblock %}

--- a/templates/suse/Dockerfile.compile.template
+++ b/templates/suse/Dockerfile.compile.template
@@ -26,6 +26,7 @@ RUN SUSEConnect -p PackageHub/{{ver}}/x86_64 \
         gcc11 \
         gcc11-c++ \
         git \
+        linux-glibc-devel \
         libevent-devel \
         libprotobuf-c-devel \
         libprotobuf-c1 \
@@ -43,7 +44,6 @@ RUN SUSEConnect -p PackageHub/{{ver}}/x86_64 \
         python3-protobuf \
         python3-tomli \
         rpm-build \
-        wget \
         which \
     && /usr/bin/python3 -B -m pip install 'tomli-w>=0.4.0' \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 \


### PR DESCRIPTION
## Description of the Changes <!-- (reasons and measures) -->
This pull request updates the Gramine Shielded Containers (GSC) to comply with the new SGX driver requirements.
As part of the https://github.com/gramineproject/gramine/pull/2061 in the Gramine master branch, the options -Dsgx_driver, -Dsgx_driver_include_path, and -Dsgx_driver_device have been removed. Similar changes should be backported into GSC as well.

 It includes modifications to the Dockerfile and entry point templates for CentOS and Debian. Additionally, it removes the `-Dsgx_driver` and `-Dsgx_driver_include_path` options when building Gramine inside the container. For further details, please refer to gramine PR #2061 

Previously, we explicitly used to locate the `sgx.h` package in `/gramine/driver` using `Dsgx_driver_include_path`. 
However, we are now installing additional package `linux-libc-dev` that provides sgx.h out of the box.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge.
-->
Fixes #227 

## How to Test This PR <!-- (if applicable) -->
Continuous Integration (CI)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/228)
<!-- Reviewable:end -->