### PR TITLE
Use methods safe from KeyError

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -69,10 +69,10 @@ def build_docker_image(docker_api, build_path, image_name, dockerfile, **kwargs)
 
 
 def extract_binary_info_from_image_config(config, env):
-    entrypoint = config['Entrypoint'] or []
+    entrypoint = config.get('Entrypoint', [])
     num_starting_entrypoint_items = len(entrypoint)
-    cmd = config['Cmd'] or []
-    working_dir = config['WorkingDir'] or ''
+    cmd = config.get('Cmd', [])
+    working_dir = config.get('WorkingDir', '')
 
     # Canonize working dir
     if working_dir == '':
@@ -115,7 +115,7 @@ def extract_binary_info_from_image_config(config, env):
 
 
 def extract_environment_from_image_config(config):
-    env_list = config['Env'] or []
+    env_list = config.get('Env', [])
     base_image_environment = ''
     for env_var in env_list:
         # TODO: switch to loader.env_src_file = "file:file_with_serialized_envs" if
@@ -158,7 +158,7 @@ def extract_define_args(args):
     return defineargs_dict
 
 def extract_user_from_image_config(config, env):
-    user = config['User']
+    user = config.get('User', 'root')
     if not user:
         user = 'root'
     env.globals.update({'app_user': user})


### PR DESCRIPTION
## Description of the changes 
During migration to the newer docker version 
```
Server: Docker Engine - Community
 Engine:
  Version:          28.2.1
  API version:      1.50 
```

It seems that the API was changed and docker engine is no longer returning empty arrays. 
Due to that we started to get following erorr:
```
  File "gsc/./gsc", line 12, in <module>
    sys.exit(main(sys.argv))
             ^^^^^^^^^^^^^^
  File "gsc/./gsc.py", line 750, in main
    return args.command(args)
           ^^^^^^^^^^^^^^^^^^
  File "gsc/./gsc.py", line 379, in gsc_build
    extract_binary_info_from_image_config(original_image.attrs['Config'], env)
  File "gsc/./gsc.py", line 72, in extract_binary_info_from_image_config
    entrypoint = config['Entrypoint'] or []
                 ~~~~~~^^^^^^^^^^^^^^
KeyError: 'Entrypoint'
```

This PR changes the way the gsc.py is reading the values from the dictionary, so it is safe from the KeyError and defaults are properly used if the key is missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/241)
<!-- Reviewable:end -->
