### PR TITLE
Replace ninja with meson for consistency with Gramine

### DIFF
--- a/templates/Dockerfile.common.compile.template
+++ b/templates/Dockerfile.common.compile.template
@@ -18,5 +18,5 @@ RUN cd /gramine \
        --buildtype={{buildtype}} \
        -Ddirect=enabled -Dsgx=enabled \
        {% if template_path(Distro).startswith('ubuntu:') %}-Ddcap=enabled{% endif %} \
-    && ninja -C build \
-    && ninja -C build install
+    && meson compile -C build/ \
+    && meson install -C build


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Currently GSC uses ninja but Gramine moved to meson for manual build and installation of Gramine.

This PR replaces ninja with meson in GSC for consistency with Gramine.

## How to test this PR? <!-- (if applicable) -->

GSC build with any example