### PR TITLE
Update meson version

### DIFF
--- a/templates/centos/Dockerfile.compile.template
+++ b/templates/centos/Dockerfile.compile.template
@@ -37,6 +37,6 @@ RUN dnf update -y \
         python3-pip \
         python3-protobuf \
         rpm-build \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.58,!=1.2.*'
 
 {% endblock %}

--- a/templates/centos/stream/Dockerfile.compile.template
+++ b/templates/centos/stream/Dockerfile.compile.template
@@ -38,6 +38,6 @@ RUN dnf distro-sync -y \
         python3-protobuf \
         rpm-build \
         yum-utils \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.58,!=1.2.*'
 
 {% endblock %}

--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -39,7 +39,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
            python3-tomli-w
         {%- else %}
            python3-pip \
-           && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+           && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.58,!=1.2.*'
         {%- endif %}
 
 COPY intel-sgx-deb.key /

--- a/templates/redhat/ubi-minimal/Dockerfile.compile.template
+++ b/templates/redhat/ubi-minimal/Dockerfile.compile.template
@@ -44,6 +44,6 @@ RUN rm -rf /etc/rhsm-host \
         python3-protobuf \
         python3-voluptuous \
         rpm-build \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.58,!=1.2.*'
 
 {% endblock %}

--- a/templates/redhat/ubi/Dockerfile.compile.template
+++ b/templates/redhat/ubi/Dockerfile.compile.template
@@ -44,6 +44,6 @@ RUN rm -rf /etc/rhsm-host \
         python3-protobuf \
         python3-voluptuous \
         rpm-build \
-    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.56,!=1.2.*'
+    && /usr/bin/python3 -B -m pip install 'tomli>=1.1.0' 'tomli-w>=0.4.0' 'meson>=0.58,!=1.2.*'
 
 {% endblock %}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Gramine moved to using meson version `meson >= 0.58` with PR  [[meson,packaging] Bump meson dependency to >= 0.58](https://github.com/gramineproject/gramine/commit/0d1a4b7607592dab4c8a720c962acee3de6b4ca8)

This PR updates meson version to be consistent with Gramine.

## How to test this PR? <!-- (if applicable) -->

Build GSC with any example

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/246)
<!-- Reviewable:end -->
