### PR TITLE
Update bullseye-backports URL to archive mirror

### DIFF
--- a/templates/debian/Dockerfile.compile.template
+++ b/templates/debian/Dockerfile.compile.template
@@ -5,8 +5,8 @@
 {% set distro = Distro.split(':') %}
 
 {%- if distro[0] == "debian" and distro[1] | int == 11 %}
-# linux-libc-dev providing sgx.h is available in the debian bullseye-backports repo for debian 11
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list \
+# linux-libc-dev providing sgx.h is available in the bullseye-backports archive for debian 11
+RUN echo 'deb http://archive.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list \
     && env DEBIAN_FRONTEND=noninteractive apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y -t bullseye-backports linux-libc-dev
 {%- endif %}


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Debian 11 (Bullseye) backports have been from active mirrors to the official archive, resulting in the following build error:
```
E: The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file.
```

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Manual testing: run `gsc build` w/ the `python:bullseye` example from our doc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/257)
<!-- Reviewable:end -->
