### PR TITLE
Raise DockerBuildError on Docker build failures

### DIFF
--- a/gsc.py
+++ b/gsc.py
@@ -28,6 +28,10 @@ class DistroRetrievalError(Exception):
                          'image. Please specify OS distro manually in the configuration file.'),
                          *args)
 
+class DockerBuildError(Exception):
+    """Exception raised when a Docker build fails."""
+    pass
+
 def test_trueish(value):
     if not value:
         return False
@@ -63,10 +67,11 @@ def build_docker_image(docker_api, build_path, image_name, dockerfile, **kwargs)
     stream = docker_api.build(path=build_path, tag=image_name, dockerfile=dockerfile,
                               decode=True, **kwargs)
     for chunk in stream:
-        if 'stream' in chunk:
+        if 'error' in chunk:
+            raise DockerBuildError(chunk['error'])
+        elif 'stream' in chunk:
             for line in chunk['stream'].splitlines():
                 print(line)
-
 
 def extract_binary_info_from_image_config(config, env):
     entrypoint = config['Entrypoint'] or []
@@ -451,8 +456,11 @@ def gsc_build(args):
     handle_redhat_repo_configs(distro, tmp_build_path)
     handle_suse_repo_configs(distro, tmp_build_path)
 
-    build_docker_image(docker_socket.api, tmp_build_path, unsigned_image_name, 'Dockerfile.build',
+    try:
+        build_docker_image(docker_socket.api, tmp_build_path, unsigned_image_name, 'Dockerfile.build',
                        rm=args.rm, nocache=args.no_cache, buildargs=extract_build_args(args))
+    except DockerBuildError as e:
+        sys.exit(f"Docker build failed: {e}")
 
     # Check if docker build failed
     if get_docker_image(docker_socket, unsigned_image_name) is None:
@@ -524,8 +532,11 @@ def gsc_build_gramine(args):
     handle_redhat_repo_configs(distro, tmp_build_path)
     handle_suse_repo_configs(distro, tmp_build_path)
 
-    build_docker_image(docker_socket.api, tmp_build_path, gramine_image_name, 'Dockerfile.compile',
-                       rm=args.rm, nocache=args.no_cache, buildargs=extract_build_args(args))
+    try:
+        build_docker_image(docker_socket.api, tmp_build_path, gramine_image_name,
+            'Dockerfile.compile', rm=args.rm, nocache=args.no_cache, buildargs=extract_build_args(args))
+    except DockerBuildError as e:
+        sys.exit(f"Docker build failed: {e}")
 
     # Check if docker build failed
     if get_docker_image(docker_socket, gramine_image_name) is None:
@@ -585,6 +596,8 @@ def gsc_sign_image(args):
         build_docker_image(docker_socket.api, tmp_build_path, signed_image_name, 'Dockerfile.sign',
                            forcerm=True, buildargs={'passphrase': args.passphrase,
                            'BUILD_ID': build_id})
+    except DockerBuildError as e:
+        sys.exit(f"Docker build failed: {e}")
     finally:
         os.remove(tmp_build_key_path)
         # Remove a temporary image created during multistage docker build to save disk space.


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, `build_docker_image()` ignored the 'error' key in the Docker API stream, relying solely on `get_docker_image()` to catch build failures. This caused the script to incorrectly report success even if a build instruction failed, when a stale Graminized image existed.

This commit adds an explicit check for the 'error' key and introduces a `DockerBuildError` exception. All callers are updated to catch this exception and exit, ensuring build failures are correctly reported.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Manual testing: run gsc build w/ the python:bullseye example from our doc.

Before this fix:
```
$ docker images
REPOSITORY   TAG                 IMAGE ID       CREATED        SIZE
gsc-python   bullseye-unsigned   e647502b2b77   3 hours ago    1.04GB

$ ./gsc build --insecure-args python:bullseye test/generic.manifest
...
Err:5 http://deb.debian.org/debian bullseye-backports Release
  404  Not Found [IP: 10.224.224.80 911]
...
Reading package lists...

E: The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file.

Successfully built an unsigned graminized Docker image `gsc-python:bullseye-unsigned` from original application image `python:bullseye`.
```

After this fix:
```
E: The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file.

Docker build failed: The command '/bin/sh -c echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list     && env DEBIAN_FRONTEND=noninteractive apt-get update     && env DEBIAN_FRONTEND=noninteractive apt-get install -y -t bullseye-backports linux-libc-dev' returned a non-zero code: 100
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/gsc/258)
<!-- Reviewable:end -->
